### PR TITLE
IE8 reads from 'styleSheet', not 'sheet'.

### DIFF
--- a/grid.js
+++ b/grid.js
@@ -947,7 +947,7 @@ var Slick = require('./core');
         $style[0].appendChild(document.createTextNode(rules.join(" ")));
       }
 
-      stylesheet = $style[0].sheet;
+      stylesheet = $style[0].sheet || $style[0].styleSheet; // IE8 -> styleSheet
 
       // cache column CSS rules
       columnCssRulesL = [];


### PR DESCRIPTION
Fixes #3.

IE8's `<style>` DOM uses `styleSheet`, but modern browsers use `sheet`.

[MSDN: `styleSheet`](http://msdn.microsoft.com/en-ca/library/ie/ms535871%28v=vs.85%29.aspx)
[MSDN: `sheet`](http://msdn.microsoft.com/en-ca/library/ie/ff974766%28v=vs.85%29.aspx)
