### PR TITLE
Remove slick grid's focus stealing on row navigate and cell render

### DIFF
--- a/grid.js
+++ b/grid.js
@@ -3041,6 +3041,11 @@ var Slick = require('./core');
         return true;
       }
 
+      if ($canvas.find(":focus").length !== 0) {
+        // steals focus from other controls on row navigation
+        setFocus();
+      }
+
       var tabbingDirections = {
         "up": -1,
         "down": 1,
@@ -3151,6 +3156,12 @@ var Slick = require('./core');
 
       // if selecting the 'add new' row, start editing right away
       setActiveCellInternal(newCell, forceEdit || (row === getDataLength()) || options.autoEdit);
+
+      // if no editor was created, set the focus back on the grid
+      if (!currentEditor && $canvas.find(":focus").length !== 0) {
+        // steals focus when a row is programatically updated
+        setFocus();
+      }
     }
 
 

--- a/grid.js
+++ b/grid.js
@@ -3041,7 +3041,7 @@ var Slick = require('./core');
         return true;
       }
 
-      if ($canvas.find(":focus").length !== 0) {
+      if (options.editable) {
         // steals focus from other controls on row navigation
         setFocus();
       }
@@ -3158,7 +3158,7 @@ var Slick = require('./core');
       setActiveCellInternal(newCell, forceEdit || (row === getDataLength()) || options.autoEdit);
 
       // if no editor was created, set the focus back on the grid
-      if (!currentEditor && $canvas.find(":focus").length !== 0) {
+      if (!options.editable && $canvas.find(":focus").length !== 0) {
         // steals focus when a row is programatically updated
         setFocus();
       }

--- a/grid.js
+++ b/grid.js
@@ -3040,7 +3040,6 @@ var Slick = require('./core');
       if (!getEditorLock().commitCurrentEdit()) {
         return true;
       }
-      setFocus();
 
       var tabbingDirections = {
         "up": -1,
@@ -3152,11 +3151,6 @@ var Slick = require('./core');
 
       // if selecting the 'add new' row, start editing right away
       setActiveCellInternal(newCell, forceEdit || (row === getDataLength()) || options.autoEdit);
-
-      // if no editor was created, set the focus back on the grid
-      if (!currentEditor) {
-        setFocus();
-      }
     }
 
 


### PR DESCRIPTION
This will remove the need for us to write custom focus handling in our ViewModels and Knockout bindings for both row navigation and programatically updating rows.

This is done by removing two `setFocus` calls that are stealing focus from other controls.  I believe they are both intended for cell edits, which we aren't using, so this might break the edit cell functionality on our fork.  It does not break the checkbox editor we use for selection.  To the best of my knowledge, slickgrid editing is not encouraged and is not currently done in any of our projects, so I have not implemented any sort of configuration flag or focus check, but this could be done in the future if we want to support slickgrid edits.


-------------
No stealing focus on row nav:
![no focus steal on row change](https://cloud.githubusercontent.com/assets/1449397/10774579/9868b000-7cc7-11e5-9d1a-637b4f679f97.gif)
-------------


No stealing focus on row update:
![no focus steal on row update](https://cloud.githubusercontent.com/assets/1449397/10774588/a480ad48-7cc7-11e5-99f8-86b90e5d43e0.gif)