### PR TITLE
Key handling

### DIFF
--- a/grid.js
+++ b/grid.js
@@ -96,7 +96,7 @@ var Slick = require('./core');
       forceSyncScrolling: false,
       addNewRowCssClass: "new-row",
       disableKeyHandler: false,
-      keyMap: {}
+      disableFocusSinkTab: false
     };
 
     var columnDefaults = {
@@ -276,7 +276,7 @@ var Slick = require('./core');
       // tab is set, so remove the focus sink from the tab.
       // leaving it turns the grid into 2 tab stops.
       // removing it all the time breaks slick grid tab stealing.
-      if ((!options.keyMap || !options.keyMap.lookup) || (options.keyMap.lookup.hasOwnProperty(9) && !options.keyMap.lookup[9])) {
+      if (options.disableFocusSinkTab) {
         $focusSink2.attr("tabindex", "-1");
       }
 

--- a/grid.js
+++ b/grid.js
@@ -95,6 +95,7 @@ var Slick = require('./core');
       defaultFormatter: defaultFormatter,
       forceSyncScrolling: false,
       addNewRowCssClass: "new-row",
+      disableKeyHandler: false,
       keyActions: {}
     };
 
@@ -328,10 +329,13 @@ var Slick = require('./core');
             .delegate(".slick-header-column", "mouseleave", handleHeaderMouseLeave);
         $headerRowScroller
             .bind("scroll", handleHeaderRowScroll);
-        $focusSink.add($focusSink2)
-            .bind("keydown", handleKeyDown);
+        if (!self.getOptions().disableKeyHandler) {
+          $focusSink.add($focusSink2)
+              .bind("keydown", handleKeyDown);
+          $canvas
+              .bind("keydown", handleKeyDown)
+        }
         $canvas
-            .bind("keydown", handleKeyDown)
             .bind("click", handleClick)
             .bind("dblclick", handleDblClick)
             .bind("contextmenu", handleContextMenu)
@@ -2213,33 +2217,32 @@ var Slick = require('./core');
 
     function handleKeyDown(e) {
       trigger(self.onKeyDown, {row: activeRow, cell: activeCell}, e);
-      if (self.getOptions().keyActions.hasOwnProperty(e.which)) { return; }
       var handled = e.isImmediatePropagationStopped();
 
       if (!handled) {
         if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
-          if (e.which == 27) {
+          if (e.which == 27) { // esc
             if (!getEditorLock().isActive()) {
               return; // no editing mode to cancel, allow bubbling and default processing (exit without cancelling the event)
             }
             cancelEditAndSetFocus();
-          } else if (e.which == 34) {
+          } else if (e.which == 34) { // space
             navigatePageDown();
             handled = true;
-          } else if (e.which == 33) {
+          } else if (e.which == 33) { // pageup
             navigatePageUp();
             handled = true;
-          } else if (e.which == 37) {
+          } else if (e.which == 37) { // pagedown
             handled = navigateLeft();
-          } else if (e.which == 39) {
+          } else if (e.which == 39) { // left
             handled = navigateRight();
-          } else if (e.which == 38) {
+          } else if (e.which == 38) { // right
             handled = navigateUp();
-          } else if (e.which == 40) {
+          } else if (e.which == 40) { // down
             handled = navigateDown();
-          } else if (e.which == 9) {
+          } else if (e.which == 9) { // tab
             handled = navigateNext();
-          } else if (e.which == 13) {
+          } else if (e.which == 13) { // enter
             if (options.editable) {
               if (currentEditor) {
                 // adding new row
@@ -2257,7 +2260,7 @@ var Slick = require('./core');
             handled = true;
           }
         } else if (e.which == 9 && e.shiftKey && !e.ctrlKey && !e.altKey) {
-          handled = navigatePrev();
+          handled = navigatePrev(); // shift tab
         }
       }
 

--- a/grid.js
+++ b/grid.js
@@ -96,7 +96,7 @@ var Slick = require('./core');
       forceSyncScrolling: false,
       addNewRowCssClass: "new-row",
       disableKeyHandler: false,
-      keyActions: {}
+      keyMap: {}
     };
 
     var columnDefaults = {
@@ -276,7 +276,7 @@ var Slick = require('./core');
       // tab is set, so remove the focus sink from the tab.
       // leaving it turns the grid into 2 tab stops.
       // removing it all the time breaks slick grid tab stealing.
-      if (!options.keyActions || (options.keyActions.hasOwnProperty(9) && !options.keyActions[9].action)) {
+      if ((!options.keyMap || !options.keyMap.lookup) || (options.keyMap.lookup.hasOwnProperty(9) && !options.keyMap.lookup[9])) {
         $focusSink2.attr("tabindex", "-1");
       }
 

--- a/grid.js
+++ b/grid.js
@@ -94,7 +94,8 @@ var Slick = require('./core');
       multiColumnSort: false,
       defaultFormatter: defaultFormatter,
       forceSyncScrolling: false,
-      addNewRowCssClass: "new-row"
+      addNewRowCssClass: "new-row",
+      keyActions: {}
     };
 
     var columnDefaults = {
@@ -271,6 +272,12 @@ var Slick = require('./core');
       $canvas = $("<div class='grid-canvas' />").appendTo($viewport);
 
       $focusSink2 = $focusSink.clone().appendTo($container);
+      // tab is set, so remove the focus sink from the tab.
+      // leaving it turns the grid into 2 tab stops.
+      // removing it all the time breaks slick grid tab stealing.
+      if (!options.keyActions || (options.keyActions.hasOwnProperty(9) && !options.keyActions[9].action)) {
+        $focusSink2.attr("tabindex", "-1");
+      }
 
       if (!options.explicitInitialization) {
         finishInitialization();
@@ -2206,6 +2213,7 @@ var Slick = require('./core');
 
     function handleKeyDown(e) {
       trigger(self.onKeyDown, {row: activeRow, cell: activeCell}, e);
+      if (self.getOptions().keyActions.hasOwnProperty(e.which)) { return; }
       var handled = e.isImmediatePropagationStopped();
 
       if (!handled) {


### PR DESCRIPTION
* Internal key handler can be disabled by setting `disableKeyHandler` to true
* `$focusSink2` is not a tabbable element if key actions are disabled or a custom tab action is set.  This was causing the grid to be 2 tab stops instead of one when browser native tabbing was enabled.

Required for https://github.com/pandell/web-pli/pull/198