### PR TITLE
jQuery dependency

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -1,154 +1,153 @@
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
-  function SlickColumnPicker(columns, grid, options) {
-    var $menu;
-    var columnCheckboxes;
 
-    var defaults = {
-      fadeSpeed:250
-    };
+function SlickColumnPicker(columns, grid, options) {
+  var $menu;
+  var columnCheckboxes;
 
-    function init() {
-      grid.onHeaderContextMenu.subscribe(handleHeaderContextMenu);
-      grid.onColumnsReordered.subscribe(updateColumnOrder);
-      options = $.extend({}, defaults, options);
+  var defaults = {
+    fadeSpeed:250
+  };
 
-      $menu = $("<span class='slick-columnpicker' style='display:none;position:absolute;z-index:20;' />").appendTo(document.body);
+  function init() {
+    grid.onHeaderContextMenu.subscribe(handleHeaderContextMenu);
+    grid.onColumnsReordered.subscribe(updateColumnOrder);
+    options = $.extend({}, defaults, options);
 
-      $menu.bind("mouseleave", function (e) {
-        $(this).fadeOut(options.fadeSpeed)
-      });
-      $menu.bind("click", updateColumn);
+    $menu = $("<span class='slick-columnpicker' style='display:none;position:absolute;z-index:20;' />").appendTo(document.body);
 
-    }
+    $menu.bind("mouseleave", function (e) {
+      $(this).fadeOut(options.fadeSpeed)
+    });
+    $menu.bind("click", updateColumn);
 
-    function destroy() {
-      grid.onHeaderContextMenu.unsubscribe(handleHeaderContextMenu);
-      grid.onColumnsReordered.unsubscribe(updateColumnOrder);
-      $menu.remove();
-    }
-
-    function handleHeaderContextMenu(e, args) {
-      e.preventDefault();
-      $menu.empty();
-      updateColumnOrder();
-      columnCheckboxes = [];
-
-      var $li, $input;
-      for (var i = 0; i < columns.length; i++) {
-        $li = $("<li />").appendTo($menu);
-        $input = $("<input type='checkbox' />").data("column-id", columns[i].id);
-        columnCheckboxes.push($input);
-
-        if (grid.getColumnIndex(columns[i].id) != null) {
-          $input.attr("checked", "checked");
-        }
-
-        $("<label />")
-            .text(columns[i].name)
-            .prepend($input)
-            .appendTo($li);
-      }
-
-      $("<hr/>").appendTo($menu);
-      $li = $("<li />").appendTo($menu);
-      $input = $("<input type='checkbox' />").data("option", "autoresize");
-      $("<label />")
-          .text("Force fit columns")
-          .prepend($input)
-          .appendTo($li);
-      if (grid.getOptions().forceFitColumns) {
-        $input.attr("checked", "checked");
-      }
-
-      $li = $("<li />").appendTo($menu);
-      $input = $("<input type='checkbox' />").data("option", "syncresize");
-      $("<label />")
-          .text("Synchronous resize")
-          .prepend($input)
-          .appendTo($li);
-      if (grid.getOptions().syncColumnCellResize) {
-        $input.attr("checked", "checked");
-      }
-
-      $menu
-          .css("top", e.pageY - 10)
-          .css("left", e.pageX - 10)
-          .fadeIn(options.fadeSpeed);
-    }
-
-    function updateColumnOrder() {
-      // Because columns can be reordered, we have to update the `columns`
-      // to reflect the new order, however we can't just take `grid.getColumns()`,
-      // as it does not include columns currently hidden by the picker.
-      // We create a new `columns` structure by leaving currently-hidden
-      // columns in their original ordinal position and interleaving the results
-      // of the current column sort.
-      var current = grid.getColumns().slice(0);
-      var ordered = new Array(columns.length);
-      for (var i = 0; i < ordered.length; i++) {
-        if ( grid.getColumnIndex(columns[i].id) === undefined ) {
-          // If the column doesn't return a value from getColumnIndex,
-          // it is hidden. Leave it in this position.
-          ordered[i] = columns[i];
-        } else {
-          // Otherwise, grab the next visible column.
-          ordered[i] = current.shift();
-        }
-      }
-      columns = ordered;
-    }
-
-    function updateColumn(e) {
-      if ($(e.target).data("option") == "autoresize") {
-        if (e.target.checked) {
-          grid.setOptions({forceFitColumns:true});
-          grid.autosizeColumns();
-        } else {
-          grid.setOptions({forceFitColumns:false});
-        }
-        return;
-      }
-
-      if ($(e.target).data("option") == "syncresize") {
-        if (e.target.checked) {
-          grid.setOptions({syncColumnCellResize:true});
-        } else {
-          grid.setOptions({syncColumnCellResize:false});
-        }
-        return;
-      }
-
-      if ($(e.target).is(":checkbox")) {
-        var visibleColumns = [];
-        $.each(columnCheckboxes, function (i, e) {
-          if ($(this).is(":checked")) {
-            visibleColumns.push(columns[i]);
-          }
-        });
-
-        if (!visibleColumns.length) {
-          $(e.target).attr("checked", "checked");
-          return;
-        }
-
-        grid.setColumns(visibleColumns);
-      }
-    }
-
-    function getAllColumns() {
-      return columns;
-    }
-
-    init();
-
-    return {
-      "getAllColumns": getAllColumns,
-      "destroy": destroy
-    };
   }
 
-  // Slick.Controls.ColumnPicker
-  $.extend(true, window, { Slick:{ Controls:{ ColumnPicker:SlickColumnPicker }}});
-})(jQuery);
+  function destroy() {
+    grid.onHeaderContextMenu.unsubscribe(handleHeaderContextMenu);
+    grid.onColumnsReordered.unsubscribe(updateColumnOrder);
+    $menu.remove();
+  }
+
+  function handleHeaderContextMenu(e, args) {
+    e.preventDefault();
+    $menu.empty();
+    updateColumnOrder();
+    columnCheckboxes = [];
+
+    var $li, $input;
+    for (var i = 0; i < columns.length; i++) {
+      $li = $("<li />").appendTo($menu);
+      $input = $("<input type='checkbox' />").data("column-id", columns[i].id);
+      columnCheckboxes.push($input);
+
+      if (grid.getColumnIndex(columns[i].id) != null) {
+        $input.attr("checked", "checked");
+      }
+
+      $("<label />")
+          .text(columns[i].name)
+          .prepend($input)
+          .appendTo($li);
+    }
+
+    $("<hr/>").appendTo($menu);
+    $li = $("<li />").appendTo($menu);
+    $input = $("<input type='checkbox' />").data("option", "autoresize");
+    $("<label />")
+        .text("Force fit columns")
+        .prepend($input)
+        .appendTo($li);
+    if (grid.getOptions().forceFitColumns) {
+      $input.attr("checked", "checked");
+    }
+
+    $li = $("<li />").appendTo($menu);
+    $input = $("<input type='checkbox' />").data("option", "syncresize");
+    $("<label />")
+        .text("Synchronous resize")
+        .prepend($input)
+        .appendTo($li);
+    if (grid.getOptions().syncColumnCellResize) {
+      $input.attr("checked", "checked");
+    }
+
+    $menu
+        .css("top", e.pageY - 10)
+        .css("left", e.pageX - 10)
+        .fadeIn(options.fadeSpeed);
+  }
+
+  function updateColumnOrder() {
+    // Because columns can be reordered, we have to update the `columns`
+    // to reflect the new order, however we can't just take `grid.getColumns()`,
+    // as it does not include columns currently hidden by the picker.
+    // We create a new `columns` structure by leaving currently-hidden
+    // columns in their original ordinal position and interleaving the results
+    // of the current column sort.
+    var current = grid.getColumns().slice(0);
+    var ordered = new Array(columns.length);
+    for (var i = 0; i < ordered.length; i++) {
+      if ( grid.getColumnIndex(columns[i].id) === undefined ) {
+        // If the column doesn't return a value from getColumnIndex,
+        // it is hidden. Leave it in this position.
+        ordered[i] = columns[i];
+      } else {
+        // Otherwise, grab the next visible column.
+        ordered[i] = current.shift();
+      }
+    }
+    columns = ordered;
+  }
+
+  function updateColumn(e) {
+    if ($(e.target).data("option") == "autoresize") {
+      if (e.target.checked) {
+        grid.setOptions({forceFitColumns:true});
+        grid.autosizeColumns();
+      } else {
+        grid.setOptions({forceFitColumns:false});
+      }
+      return;
+    }
+
+    if ($(e.target).data("option") == "syncresize") {
+      if (e.target.checked) {
+        grid.setOptions({syncColumnCellResize:true});
+      } else {
+        grid.setOptions({syncColumnCellResize:false});
+      }
+      return;
+    }
+
+    if ($(e.target).is(":checkbox")) {
+      var visibleColumns = [];
+      $.each(columnCheckboxes, function (i, e) {
+        if ($(this).is(":checked")) {
+          visibleColumns.push(columns[i]);
+        }
+      });
+
+      if (!visibleColumns.length) {
+        $(e.target).attr("checked", "checked");
+        return;
+      }
+
+      grid.setColumns(visibleColumns);
+    }
+  }
+
+  function getAllColumns() {
+    return columns;
+  }
+
+  init();
+
+  return {
+    "getAllColumns": getAllColumns,
+    "destroy": destroy
+  };
+}
+
+// Slick.Controls.ColumnPicker
+$.extend(true, window, { Slick:{ Controls:{ ColumnPicker:SlickColumnPicker }}});

--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -1,3 +1,5 @@
+var jQuery = require("jquery");
+
 (function ($) {
   function SlickColumnPicker(columns, grid, options) {
     var $menu;

--- a/controls/slick.pager.js
+++ b/controls/slick.pager.js
@@ -1,156 +1,156 @@
-var jQuery = require("jquery");
-
-(function ($) {
-  function SlickGridPager(dataView, grid, $container) {
-    var $status;
-
-    function init() {
-      dataView.onPagingInfoChanged.subscribe(function (e, pagingInfo) {
-        updatePager(pagingInfo);
-      });
-
-      constructPagerUI();
-      updatePager(dataView.getPagingInfo());
-    }
-
-    function getNavState() {
-      var cannotLeaveEditMode = !Slick.GlobalEditorLock.commitCurrentEdit();
-      var pagingInfo = dataView.getPagingInfo();
-      var lastPage = pagingInfo.totalPages - 1;
-
-      return {
-        canGotoFirst: !cannotLeaveEditMode && pagingInfo.pageSize != 0 && pagingInfo.pageNum > 0,
-        canGotoLast: !cannotLeaveEditMode && pagingInfo.pageSize != 0 && pagingInfo.pageNum != lastPage,
-        canGotoPrev: !cannotLeaveEditMode && pagingInfo.pageSize != 0 && pagingInfo.pageNum > 0,
-        canGotoNext: !cannotLeaveEditMode && pagingInfo.pageSize != 0 && pagingInfo.pageNum < lastPage,
-        pagingInfo: pagingInfo
-      }
-    }
-
-    function setPageSize(n) {
-      dataView.setRefreshHints({
-        isFilterUnchanged: true
-      });
-      dataView.setPagingOptions({pageSize: n});
-    }
-
-    function gotoFirst() {
-      if (getNavState().canGotoFirst) {
-        dataView.setPagingOptions({pageNum: 0});
-      }
-    }
-
-    function gotoLast() {
-      var state = getNavState();
-      if (state.canGotoLast) {
-        dataView.setPagingOptions({pageNum: state.pagingInfo.totalPages - 1});
-      }
-    }
-
-    function gotoPrev() {
-      var state = getNavState();
-      if (state.canGotoPrev) {
-        dataView.setPagingOptions({pageNum: state.pagingInfo.pageNum - 1});
-      }
-    }
-
-    function gotoNext() {
-      var state = getNavState();
-      if (state.canGotoNext) {
-        dataView.setPagingOptions({pageNum: state.pagingInfo.pageNum + 1});
-      }
-    }
-
-    function constructPagerUI() {
-      $container.empty();
-
-      var $nav = $("<span class='slick-pager-nav' />").appendTo($container);
-      var $settings = $("<span class='slick-pager-settings' />").appendTo($container);
-      $status = $("<span class='slick-pager-status' />").appendTo($container);
-
-      $settings
-          .append("<span class='slick-pager-settings-expanded' style='display:none'>Show: <a data=0>All</a><a data='-1'>Auto</a><a data=25>25</a><a data=50>50</a><a data=100>100</a></span>");
-
-      $settings.find("a[data]").click(function (e) {
-        var pagesize = $(e.target).attr("data");
-        if (pagesize != undefined) {
-          if (pagesize == -1) {
-            var vp = grid.getViewport();
-            setPageSize(vp.bottom - vp.top);
-          } else {
-            setPageSize(parseInt(pagesize));
-          }
-        }
-      });
-
-      var icon_prefix = "<span class='ui-state-default ui-corner-all ui-icon-container'><span class='ui-icon ";
-      var icon_suffix = "' /></span>";
-
-      $(icon_prefix + "ui-icon-lightbulb" + icon_suffix)
-          .click(function () {
-            $(".slick-pager-settings-expanded").toggle()
-          })
-          .appendTo($settings);
-
-      $(icon_prefix + "ui-icon-seek-first" + icon_suffix)
-          .click(gotoFirst)
-          .appendTo($nav);
-
-      $(icon_prefix + "ui-icon-seek-prev" + icon_suffix)
-          .click(gotoPrev)
-          .appendTo($nav);
-
-      $(icon_prefix + "ui-icon-seek-next" + icon_suffix)
-          .click(gotoNext)
-          .appendTo($nav);
-
-      $(icon_prefix + "ui-icon-seek-end" + icon_suffix)
-          .click(gotoLast)
-          .appendTo($nav);
-
-      $container.find(".ui-icon-container")
-          .hover(function () {
-            $(this).toggleClass("ui-state-hover");
-          });
-
-      $container.children().wrapAll("<div class='slick-pager' />");
-    }
+var $ = require("jquery");
 
 
-    function updatePager(pagingInfo) {
-      var state = getNavState();
+function SlickGridPager(dataView, grid, $container) {
+  var $status;
 
-      $container.find(".slick-pager-nav span").removeClass("ui-state-disabled");
-      if (!state.canGotoFirst) {
-        $container.find(".ui-icon-seek-first").addClass("ui-state-disabled");
-      }
-      if (!state.canGotoLast) {
-        $container.find(".ui-icon-seek-end").addClass("ui-state-disabled");
-      }
-      if (!state.canGotoNext) {
-        $container.find(".ui-icon-seek-next").addClass("ui-state-disabled");
-      }
-      if (!state.canGotoPrev) {
-        $container.find(".ui-icon-seek-prev").addClass("ui-state-disabled");
-      }
+  function init() {
+    dataView.onPagingInfoChanged.subscribe(function (e, pagingInfo) {
+      updatePager(pagingInfo);
+    });
 
-      if (pagingInfo.pageSize == 0) {
-        var totalRowsCount = dataView.getItems().length;
-        var visibleRowsCount = pagingInfo.totalRows;
-        if (visibleRowsCount < totalRowsCount) {
-          $status.text("Showing " + visibleRowsCount + " of " + totalRowsCount + " rows");
-        } else {
-          $status.text("Showing all " + totalRowsCount + " rows");
-        }
-        $status.text("Showing all " + pagingInfo.totalRows + " rows");
-      } else {
-        $status.text("Showing page " + (pagingInfo.pageNum + 1) + " of " + pagingInfo.totalPages);
-      }
-    }
-
-    init();
+    constructPagerUI();
+    updatePager(dataView.getPagingInfo());
   }
 
-  // Slick.Controls.Pager
-  $.extend(true, window, { Slick:{ Controls:{ Pager:SlickGridPager }}});
-})(jQuery);
+  function getNavState() {
+    var cannotLeaveEditMode = !Slick.GlobalEditorLock.commitCurrentEdit();
+    var pagingInfo = dataView.getPagingInfo();
+    var lastPage = pagingInfo.totalPages - 1;
+
+    return {
+      canGotoFirst: !cannotLeaveEditMode && pagingInfo.pageSize != 0 && pagingInfo.pageNum > 0,
+      canGotoLast: !cannotLeaveEditMode && pagingInfo.pageSize != 0 && pagingInfo.pageNum != lastPage,
+      canGotoPrev: !cannotLeaveEditMode && pagingInfo.pageSize != 0 && pagingInfo.pageNum > 0,
+      canGotoNext: !cannotLeaveEditMode && pagingInfo.pageSize != 0 && pagingInfo.pageNum < lastPage,
+      pagingInfo: pagingInfo
+    }
+  }
+
+  function setPageSize(n) {
+    dataView.setRefreshHints({
+      isFilterUnchanged: true
+    });
+    dataView.setPagingOptions({pageSize: n});
+  }
+
+  function gotoFirst() {
+    if (getNavState().canGotoFirst) {
+      dataView.setPagingOptions({pageNum: 0});
+    }
+  }
+
+  function gotoLast() {
+    var state = getNavState();
+    if (state.canGotoLast) {
+      dataView.setPagingOptions({pageNum: state.pagingInfo.totalPages - 1});
+    }
+  }
+
+  function gotoPrev() {
+    var state = getNavState();
+    if (state.canGotoPrev) {
+      dataView.setPagingOptions({pageNum: state.pagingInfo.pageNum - 1});
+    }
+  }
+
+  function gotoNext() {
+    var state = getNavState();
+    if (state.canGotoNext) {
+      dataView.setPagingOptions({pageNum: state.pagingInfo.pageNum + 1});
+    }
+  }
+
+  function constructPagerUI() {
+    $container.empty();
+
+    var $nav = $("<span class='slick-pager-nav' />").appendTo($container);
+    var $settings = $("<span class='slick-pager-settings' />").appendTo($container);
+    $status = $("<span class='slick-pager-status' />").appendTo($container);
+
+    $settings
+        .append("<span class='slick-pager-settings-expanded' style='display:none'>Show: <a data=0>All</a><a data='-1'>Auto</a><a data=25>25</a><a data=50>50</a><a data=100>100</a></span>");
+
+    $settings.find("a[data]").click(function (e) {
+      var pagesize = $(e.target).attr("data");
+      if (pagesize != undefined) {
+        if (pagesize == -1) {
+          var vp = grid.getViewport();
+          setPageSize(vp.bottom - vp.top);
+        } else {
+          setPageSize(parseInt(pagesize));
+        }
+      }
+    });
+
+    var icon_prefix = "<span class='ui-state-default ui-corner-all ui-icon-container'><span class='ui-icon ";
+    var icon_suffix = "' /></span>";
+
+    $(icon_prefix + "ui-icon-lightbulb" + icon_suffix)
+        .click(function () {
+          $(".slick-pager-settings-expanded").toggle()
+        })
+        .appendTo($settings);
+
+    $(icon_prefix + "ui-icon-seek-first" + icon_suffix)
+        .click(gotoFirst)
+        .appendTo($nav);
+
+    $(icon_prefix + "ui-icon-seek-prev" + icon_suffix)
+        .click(gotoPrev)
+        .appendTo($nav);
+
+    $(icon_prefix + "ui-icon-seek-next" + icon_suffix)
+        .click(gotoNext)
+        .appendTo($nav);
+
+    $(icon_prefix + "ui-icon-seek-end" + icon_suffix)
+        .click(gotoLast)
+        .appendTo($nav);
+
+    $container.find(".ui-icon-container")
+        .hover(function () {
+          $(this).toggleClass("ui-state-hover");
+        });
+
+    $container.children().wrapAll("<div class='slick-pager' />");
+  }
+
+
+  function updatePager(pagingInfo) {
+    var state = getNavState();
+
+    $container.find(".slick-pager-nav span").removeClass("ui-state-disabled");
+    if (!state.canGotoFirst) {
+      $container.find(".ui-icon-seek-first").addClass("ui-state-disabled");
+    }
+    if (!state.canGotoLast) {
+      $container.find(".ui-icon-seek-end").addClass("ui-state-disabled");
+    }
+    if (!state.canGotoNext) {
+      $container.find(".ui-icon-seek-next").addClass("ui-state-disabled");
+    }
+    if (!state.canGotoPrev) {
+      $container.find(".ui-icon-seek-prev").addClass("ui-state-disabled");
+    }
+
+    if (pagingInfo.pageSize == 0) {
+      var totalRowsCount = dataView.getItems().length;
+      var visibleRowsCount = pagingInfo.totalRows;
+      if (visibleRowsCount < totalRowsCount) {
+        $status.text("Showing " + visibleRowsCount + " of " + totalRowsCount + " rows");
+      } else {
+        $status.text("Showing all " + totalRowsCount + " rows");
+      }
+      $status.text("Showing all " + pagingInfo.totalRows + " rows");
+    } else {
+      $status.text("Showing page " + (pagingInfo.pageNum + 1) + " of " + pagingInfo.totalPages);
+    }
+  }
+
+  init();
+}
+
+// Slick.Controls.Pager
+$.extend(true, window, { Slick:{ Controls:{ Pager:SlickGridPager }}});
+

--- a/controls/slick.pager.js
+++ b/controls/slick.pager.js
@@ -1,3 +1,5 @@
+var jQuery = require("jquery");
+
 (function ($) {
   function SlickGridPager(dataView, grid, $container) {
     var $status;

--- a/editors.js
+++ b/editors.js
@@ -4,6 +4,8 @@
  * @namespace Slick
  */
 
+var jQuery = require("jquery");
+
 (function ($) {
   // register namespace
   $.extend(true, window, {

--- a/editors.js
+++ b/editors.js
@@ -4,511 +4,510 @@
  * @namespace Slick
  */
 
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Editors": {
-        "Text": TextEditor,
-        "Integer": IntegerEditor,
-        "Date": DateEditor,
-        "YesNoSelect": YesNoSelectEditor,
-        "Checkbox": CheckboxEditor,
-        "PercentComplete": PercentCompleteEditor,
-        "LongText": LongTextEditor
+
+// register namespace
+$.extend(true, window, {
+  "Slick": {
+    "Editors": {
+      "Text": TextEditor,
+      "Integer": IntegerEditor,
+      "Date": DateEditor,
+      "YesNoSelect": YesNoSelectEditor,
+      "Checkbox": CheckboxEditor,
+      "PercentComplete": PercentCompleteEditor,
+      "LongText": LongTextEditor
+    }
+  }
+});
+
+function TextEditor(args) {
+  var $input;
+  var defaultValue;
+  var scope = this;
+
+  this.init = function () {
+    $input = $("<INPUT type=text class='editor-text' />")
+        .appendTo(args.container)
+        .bind("keydown.nav", function (e) {
+          if (e.keyCode === $.ui.keyCode.LEFT || e.keyCode === $.ui.keyCode.RIGHT) {
+            e.stopImmediatePropagation();
+          }
+        })
+        .focus()
+        .select();
+  };
+
+  this.destroy = function () {
+    $input.remove();
+  };
+
+  this.focus = function () {
+    $input.focus();
+  };
+
+  this.getValue = function () {
+    return $input.val();
+  };
+
+  this.setValue = function (val) {
+    $input.val(val);
+  };
+
+  this.loadValue = function (item) {
+    defaultValue = item[args.column.field] || "";
+    $input.val(defaultValue);
+    $input[0].defaultValue = defaultValue;
+    $input.select();
+  };
+
+  this.serializeValue = function () {
+    return $input.val();
+  };
+
+  this.applyValue = function (item, state) {
+    item[args.column.field] = state;
+  };
+
+  this.isValueChanged = function () {
+    return (!($input.val() == "" && defaultValue == null)) && ($input.val() != defaultValue);
+  };
+
+  this.validate = function () {
+    if (args.column.validator) {
+      var validationResults = args.column.validator($input.val());
+      if (!validationResults.valid) {
+        return validationResults;
       }
     }
-  });
 
-  function TextEditor(args) {
-    var $input;
-    var defaultValue;
-    var scope = this;
-
-    this.init = function () {
-      $input = $("<INPUT type=text class='editor-text' />")
-          .appendTo(args.container)
-          .bind("keydown.nav", function (e) {
-            if (e.keyCode === $.ui.keyCode.LEFT || e.keyCode === $.ui.keyCode.RIGHT) {
-              e.stopImmediatePropagation();
-            }
-          })
-          .focus()
-          .select();
+    return {
+      valid: true,
+      msg: null
     };
+  };
 
-    this.destroy = function () {
-      $input.remove();
-    };
+  this.init();
+}
 
-    this.focus = function () {
-      $input.focus();
-    };
+function IntegerEditor(args) {
+  var $input;
+  var defaultValue;
+  var scope = this;
 
-    this.getValue = function () {
-      return $input.val();
-    };
+  this.init = function () {
+    $input = $("<INPUT type=text class='editor-text' />");
 
-    this.setValue = function (val) {
-      $input.val(val);
-    };
-
-    this.loadValue = function (item) {
-      defaultValue = item[args.column.field] || "";
-      $input.val(defaultValue);
-      $input[0].defaultValue = defaultValue;
-      $input.select();
-    };
-
-    this.serializeValue = function () {
-      return $input.val();
-    };
-
-    this.applyValue = function (item, state) {
-      item[args.column.field] = state;
-    };
-
-    this.isValueChanged = function () {
-      return (!($input.val() == "" && defaultValue == null)) && ($input.val() != defaultValue);
-    };
-
-    this.validate = function () {
-      if (args.column.validator) {
-        var validationResults = args.column.validator($input.val());
-        if (!validationResults.valid) {
-          return validationResults;
-        }
+    $input.bind("keydown.nav", function (e) {
+      if (e.keyCode === $.ui.keyCode.LEFT || e.keyCode === $.ui.keyCode.RIGHT) {
+        e.stopImmediatePropagation();
       }
+    });
 
+    $input.appendTo(args.container);
+    $input.focus().select();
+  };
+
+  this.destroy = function () {
+    $input.remove();
+  };
+
+  this.focus = function () {
+    $input.focus();
+  };
+
+  this.loadValue = function (item) {
+    defaultValue = item[args.column.field];
+    $input.val(defaultValue);
+    $input[0].defaultValue = defaultValue;
+    $input.select();
+  };
+
+  this.serializeValue = function () {
+    return parseInt($input.val(), 10) || 0;
+  };
+
+  this.applyValue = function (item, state) {
+    item[args.column.field] = state;
+  };
+
+  this.isValueChanged = function () {
+    return (!($input.val() == "" && defaultValue == null)) && ($input.val() != defaultValue);
+  };
+
+  this.validate = function () {
+    if (isNaN($input.val())) {
       return {
-        valid: true,
-        msg: null
+        valid: false,
+        msg: "Please enter a valid integer"
       };
+    }
+
+    return {
+      valid: true,
+      msg: null
     };
+  };
 
-    this.init();
-  }
+  this.init();
+}
 
-  function IntegerEditor(args) {
-    var $input;
-    var defaultValue;
-    var scope = this;
+function DateEditor(args) {
+  var $input;
+  var defaultValue;
+  var scope = this;
+  var calendarOpen = false;
 
-    this.init = function () {
-      $input = $("<INPUT type=text class='editor-text' />");
-
-      $input.bind("keydown.nav", function (e) {
-        if (e.keyCode === $.ui.keyCode.LEFT || e.keyCode === $.ui.keyCode.RIGHT) {
-          e.stopImmediatePropagation();
-        }
-      });
-
-      $input.appendTo(args.container);
-      $input.focus().select();
-    };
-
-    this.destroy = function () {
-      $input.remove();
-    };
-
-    this.focus = function () {
-      $input.focus();
-    };
-
-    this.loadValue = function (item) {
-      defaultValue = item[args.column.field];
-      $input.val(defaultValue);
-      $input[0].defaultValue = defaultValue;
-      $input.select();
-    };
-
-    this.serializeValue = function () {
-      return parseInt($input.val(), 10) || 0;
-    };
-
-    this.applyValue = function (item, state) {
-      item[args.column.field] = state;
-    };
-
-    this.isValueChanged = function () {
-      return (!($input.val() == "" && defaultValue == null)) && ($input.val() != defaultValue);
-    };
-
-    this.validate = function () {
-      if (isNaN($input.val())) {
-        return {
-          valid: false,
-          msg: "Please enter a valid integer"
-        };
+  this.init = function () {
+    $input = $("<INPUT type=text class='editor-text' />");
+    $input.appendTo(args.container);
+    $input.focus().select();
+    $input.datepicker({
+      showOn: "button",
+      buttonImageOnly: true,
+      buttonImage: "../images/calendar.gif",
+      beforeShow: function () {
+        calendarOpen = true
+      },
+      onClose: function () {
+        calendarOpen = false
       }
+    });
+    $input.width($input.width() - 18);
+  };
 
+  this.destroy = function () {
+    $.datepicker.dpDiv.stop(true, true);
+    $input.datepicker("hide");
+    $input.datepicker("destroy");
+    $input.remove();
+  };
+
+  this.show = function () {
+    if (calendarOpen) {
+      $.datepicker.dpDiv.stop(true, true).show();
+    }
+  };
+
+  this.hide = function () {
+    if (calendarOpen) {
+      $.datepicker.dpDiv.stop(true, true).hide();
+    }
+  };
+
+  this.position = function (position) {
+    if (!calendarOpen) {
+      return;
+    }
+    $.datepicker.dpDiv
+        .css("top", position.top + 30)
+        .css("left", position.left);
+  };
+
+  this.focus = function () {
+    $input.focus();
+  };
+
+  this.loadValue = function (item) {
+    defaultValue = item[args.column.field];
+    $input.val(defaultValue);
+    $input[0].defaultValue = defaultValue;
+    $input.select();
+  };
+
+  this.serializeValue = function () {
+    return $input.val();
+  };
+
+  this.applyValue = function (item, state) {
+    item[args.column.field] = state;
+  };
+
+  this.isValueChanged = function () {
+    return (!($input.val() == "" && defaultValue == null)) && ($input.val() != defaultValue);
+  };
+
+  this.validate = function () {
+    return {
+      valid: true,
+      msg: null
+    };
+  };
+
+  this.init();
+}
+
+function YesNoSelectEditor(args) {
+  var $select;
+  var defaultValue;
+  var scope = this;
+
+  this.init = function () {
+    $select = $("<SELECT tabIndex='0' class='editor-yesno'><OPTION value='yes'>Yes</OPTION><OPTION value='no'>No</OPTION></SELECT>");
+    $select.appendTo(args.container);
+    $select.focus();
+  };
+
+  this.destroy = function () {
+    $select.remove();
+  };
+
+  this.focus = function () {
+    $select.focus();
+  };
+
+  this.loadValue = function (item) {
+    $select.val((defaultValue = item[args.column.field]) ? "yes" : "no");
+    $select.select();
+  };
+
+  this.serializeValue = function () {
+    return ($select.val() == "yes");
+  };
+
+  this.applyValue = function (item, state) {
+    item[args.column.field] = state;
+  };
+
+  this.isValueChanged = function () {
+    return ($select.val() != defaultValue);
+  };
+
+  this.validate = function () {
+    return {
+      valid: true,
+      msg: null
+    };
+  };
+
+  this.init();
+}
+
+function CheckboxEditor(args) {
+  var $select;
+  var defaultValue;
+  var scope = this;
+
+  this.init = function () {
+    $select = $("<INPUT type=checkbox value='true' class='editor-checkbox' hideFocus>");
+    $select.appendTo(args.container);
+    $select.focus();
+  };
+
+  this.destroy = function () {
+    $select.remove();
+  };
+
+  this.focus = function () {
+    $select.focus();
+  };
+
+  this.loadValue = function (item) {
+    defaultValue = !!item[args.column.field];
+    if (defaultValue) {
+      $select.prop('checked', true);
+    } else {
+      $select.prop('checked', false);
+    }
+  };
+
+  this.serializeValue = function () {
+    return $select.prop('checked');
+  };
+
+  this.applyValue = function (item, state) {
+    item[args.column.field] = state;
+  };
+
+  this.isValueChanged = function () {
+    return (this.serializeValue() !== defaultValue);
+  };
+
+  this.validate = function () {
+    return {
+      valid: true,
+      msg: null
+    };
+  };
+
+  this.init();
+}
+
+function PercentCompleteEditor(args) {
+  var $input, $picker;
+  var defaultValue;
+  var scope = this;
+
+  this.init = function () {
+    $input = $("<INPUT type=text class='editor-percentcomplete' />");
+    $input.width($(args.container).innerWidth() - 25);
+    $input.appendTo(args.container);
+
+    $picker = $("<div class='editor-percentcomplete-picker' />").appendTo(args.container);
+    $picker.append("<div class='editor-percentcomplete-helper'><div class='editor-percentcomplete-wrapper'><div class='editor-percentcomplete-slider' /><div class='editor-percentcomplete-buttons' /></div></div>");
+
+    $picker.find(".editor-percentcomplete-buttons").append("<button val=0>Not started</button><br/><button val=50>In Progress</button><br/><button val=100>Complete</button>");
+
+    $input.focus().select();
+
+    $picker.find(".editor-percentcomplete-slider").slider({
+      orientation: "vertical",
+      range: "min",
+      value: defaultValue,
+      slide: function (event, ui) {
+        $input.val(ui.value)
+      }
+    });
+
+    $picker.find(".editor-percentcomplete-buttons button").bind("click", function (e) {
+      $input.val($(this).attr("val"));
+      $picker.find(".editor-percentcomplete-slider").slider("value", $(this).attr("val"));
+    })
+  };
+
+  this.destroy = function () {
+    $input.remove();
+    $picker.remove();
+  };
+
+  this.focus = function () {
+    $input.focus();
+  };
+
+  this.loadValue = function (item) {
+    $input.val(defaultValue = item[args.column.field]);
+    $input.select();
+  };
+
+  this.serializeValue = function () {
+    return parseInt($input.val(), 10) || 0;
+  };
+
+  this.applyValue = function (item, state) {
+    item[args.column.field] = state;
+  };
+
+  this.isValueChanged = function () {
+    return (!($input.val() == "" && defaultValue == null)) && ((parseInt($input.val(), 10) || 0) != defaultValue);
+  };
+
+  this.validate = function () {
+    if (isNaN(parseInt($input.val(), 10))) {
       return {
-        valid: true,
-        msg: null
+        valid: false,
+        msg: "Please enter a valid positive number"
       };
+    }
+
+    return {
+      valid: true,
+      msg: null
     };
+  };
 
-    this.init();
-  }
+  this.init();
+}
 
-  function DateEditor(args) {
-    var $input;
-    var defaultValue;
-    var scope = this;
-    var calendarOpen = false;
+/*
+ * An example of a "detached" editor.
+ * The UI is added onto document BODY and .position(), .show() and .hide() are implemented.
+ * KeyDown events are also handled to provide handling for Tab, Shift-Tab, Esc and Ctrl-Enter.
+ */
+function LongTextEditor(args) {
+  var $input, $wrapper;
+  var defaultValue;
+  var scope = this;
 
-    this.init = function () {
-      $input = $("<INPUT type=text class='editor-text' />");
-      $input.appendTo(args.container);
-      $input.focus().select();
-      $input.datepicker({
-        showOn: "button",
-        buttonImageOnly: true,
-        buttonImage: "../images/calendar.gif",
-        beforeShow: function () {
-          calendarOpen = true
-        },
-        onClose: function () {
-          calendarOpen = false
-        }
-      });
-      $input.width($input.width() - 18);
+  this.init = function () {
+    var $container = $("body");
+
+    $wrapper = $("<DIV style='z-index:10000;position:absolute;background:white;padding:5px;border:3px solid gray; -moz-border-radius:10px; border-radius:10px;'/>")
+        .appendTo($container);
+
+    $input = $("<TEXTAREA hidefocus rows=5 style='backround:white;width:250px;height:80px;border:0;outline:0'>")
+        .appendTo($wrapper);
+
+    $("<DIV style='text-align:right'><BUTTON>Save</BUTTON><BUTTON>Cancel</BUTTON></DIV>")
+        .appendTo($wrapper);
+
+    $wrapper.find("button:first").bind("click", this.save);
+    $wrapper.find("button:last").bind("click", this.cancel);
+    $input.bind("keydown", this.handleKeyDown);
+
+    scope.position(args.position);
+    $input.focus().select();
+  };
+
+  this.handleKeyDown = function (e) {
+    if (e.which == $.ui.keyCode.ENTER && e.ctrlKey) {
+      scope.save();
+    } else if (e.which == $.ui.keyCode.ESCAPE) {
+      e.preventDefault();
+      scope.cancel();
+    } else if (e.which == $.ui.keyCode.TAB && e.shiftKey) {
+      e.preventDefault();
+      args.grid.navigatePrev();
+    } else if (e.which == $.ui.keyCode.TAB) {
+      e.preventDefault();
+      args.grid.navigateNext();
+    }
+  };
+
+  this.save = function () {
+    args.commitChanges();
+  };
+
+  this.cancel = function () {
+    $input.val(defaultValue);
+    args.cancelChanges();
+  };
+
+  this.hide = function () {
+    $wrapper.hide();
+  };
+
+  this.show = function () {
+    $wrapper.show();
+  };
+
+  this.position = function (position) {
+    $wrapper
+        .css("top", position.top - 5)
+        .css("left", position.left - 5)
+  };
+
+  this.destroy = function () {
+    $wrapper.remove();
+  };
+
+  this.focus = function () {
+    $input.focus();
+  };
+
+  this.loadValue = function (item) {
+    $input.val(defaultValue = item[args.column.field]);
+    $input.select();
+  };
+
+  this.serializeValue = function () {
+    return $input.val();
+  };
+
+  this.applyValue = function (item, state) {
+    item[args.column.field] = state;
+  };
+
+  this.isValueChanged = function () {
+    return (!($input.val() == "" && defaultValue == null)) && ($input.val() != defaultValue);
+  };
+
+  this.validate = function () {
+    return {
+      valid: true,
+      msg: null
     };
+  };
 
-    this.destroy = function () {
-      $.datepicker.dpDiv.stop(true, true);
-      $input.datepicker("hide");
-      $input.datepicker("destroy");
-      $input.remove();
-    };
-
-    this.show = function () {
-      if (calendarOpen) {
-        $.datepicker.dpDiv.stop(true, true).show();
-      }
-    };
-
-    this.hide = function () {
-      if (calendarOpen) {
-        $.datepicker.dpDiv.stop(true, true).hide();
-      }
-    };
-
-    this.position = function (position) {
-      if (!calendarOpen) {
-        return;
-      }
-      $.datepicker.dpDiv
-          .css("top", position.top + 30)
-          .css("left", position.left);
-    };
-
-    this.focus = function () {
-      $input.focus();
-    };
-
-    this.loadValue = function (item) {
-      defaultValue = item[args.column.field];
-      $input.val(defaultValue);
-      $input[0].defaultValue = defaultValue;
-      $input.select();
-    };
-
-    this.serializeValue = function () {
-      return $input.val();
-    };
-
-    this.applyValue = function (item, state) {
-      item[args.column.field] = state;
-    };
-
-    this.isValueChanged = function () {
-      return (!($input.val() == "" && defaultValue == null)) && ($input.val() != defaultValue);
-    };
-
-    this.validate = function () {
-      return {
-        valid: true,
-        msg: null
-      };
-    };
-
-    this.init();
-  }
-
-  function YesNoSelectEditor(args) {
-    var $select;
-    var defaultValue;
-    var scope = this;
-
-    this.init = function () {
-      $select = $("<SELECT tabIndex='0' class='editor-yesno'><OPTION value='yes'>Yes</OPTION><OPTION value='no'>No</OPTION></SELECT>");
-      $select.appendTo(args.container);
-      $select.focus();
-    };
-
-    this.destroy = function () {
-      $select.remove();
-    };
-
-    this.focus = function () {
-      $select.focus();
-    };
-
-    this.loadValue = function (item) {
-      $select.val((defaultValue = item[args.column.field]) ? "yes" : "no");
-      $select.select();
-    };
-
-    this.serializeValue = function () {
-      return ($select.val() == "yes");
-    };
-
-    this.applyValue = function (item, state) {
-      item[args.column.field] = state;
-    };
-
-    this.isValueChanged = function () {
-      return ($select.val() != defaultValue);
-    };
-
-    this.validate = function () {
-      return {
-        valid: true,
-        msg: null
-      };
-    };
-
-    this.init();
-  }
-
-  function CheckboxEditor(args) {
-    var $select;
-    var defaultValue;
-    var scope = this;
-
-    this.init = function () {
-      $select = $("<INPUT type=checkbox value='true' class='editor-checkbox' hideFocus>");
-      $select.appendTo(args.container);
-      $select.focus();
-    };
-
-    this.destroy = function () {
-      $select.remove();
-    };
-
-    this.focus = function () {
-      $select.focus();
-    };
-
-    this.loadValue = function (item) {
-      defaultValue = !!item[args.column.field];
-      if (defaultValue) {
-        $select.prop('checked', true);
-      } else {
-        $select.prop('checked', false);
-      }
-    };
-
-    this.serializeValue = function () {
-      return $select.prop('checked');
-    };
-
-    this.applyValue = function (item, state) {
-      item[args.column.field] = state;
-    };
-
-    this.isValueChanged = function () {
-      return (this.serializeValue() !== defaultValue);
-    };
-
-    this.validate = function () {
-      return {
-        valid: true,
-        msg: null
-      };
-    };
-
-    this.init();
-  }
-
-  function PercentCompleteEditor(args) {
-    var $input, $picker;
-    var defaultValue;
-    var scope = this;
-
-    this.init = function () {
-      $input = $("<INPUT type=text class='editor-percentcomplete' />");
-      $input.width($(args.container).innerWidth() - 25);
-      $input.appendTo(args.container);
-
-      $picker = $("<div class='editor-percentcomplete-picker' />").appendTo(args.container);
-      $picker.append("<div class='editor-percentcomplete-helper'><div class='editor-percentcomplete-wrapper'><div class='editor-percentcomplete-slider' /><div class='editor-percentcomplete-buttons' /></div></div>");
-
-      $picker.find(".editor-percentcomplete-buttons").append("<button val=0>Not started</button><br/><button val=50>In Progress</button><br/><button val=100>Complete</button>");
-
-      $input.focus().select();
-
-      $picker.find(".editor-percentcomplete-slider").slider({
-        orientation: "vertical",
-        range: "min",
-        value: defaultValue,
-        slide: function (event, ui) {
-          $input.val(ui.value)
-        }
-      });
-
-      $picker.find(".editor-percentcomplete-buttons button").bind("click", function (e) {
-        $input.val($(this).attr("val"));
-        $picker.find(".editor-percentcomplete-slider").slider("value", $(this).attr("val"));
-      })
-    };
-
-    this.destroy = function () {
-      $input.remove();
-      $picker.remove();
-    };
-
-    this.focus = function () {
-      $input.focus();
-    };
-
-    this.loadValue = function (item) {
-      $input.val(defaultValue = item[args.column.field]);
-      $input.select();
-    };
-
-    this.serializeValue = function () {
-      return parseInt($input.val(), 10) || 0;
-    };
-
-    this.applyValue = function (item, state) {
-      item[args.column.field] = state;
-    };
-
-    this.isValueChanged = function () {
-      return (!($input.val() == "" && defaultValue == null)) && ((parseInt($input.val(), 10) || 0) != defaultValue);
-    };
-
-    this.validate = function () {
-      if (isNaN(parseInt($input.val(), 10))) {
-        return {
-          valid: false,
-          msg: "Please enter a valid positive number"
-        };
-      }
-
-      return {
-        valid: true,
-        msg: null
-      };
-    };
-
-    this.init();
-  }
-
-  /*
-   * An example of a "detached" editor.
-   * The UI is added onto document BODY and .position(), .show() and .hide() are implemented.
-   * KeyDown events are also handled to provide handling for Tab, Shift-Tab, Esc and Ctrl-Enter.
-   */
-  function LongTextEditor(args) {
-    var $input, $wrapper;
-    var defaultValue;
-    var scope = this;
-
-    this.init = function () {
-      var $container = $("body");
-
-      $wrapper = $("<DIV style='z-index:10000;position:absolute;background:white;padding:5px;border:3px solid gray; -moz-border-radius:10px; border-radius:10px;'/>")
-          .appendTo($container);
-
-      $input = $("<TEXTAREA hidefocus rows=5 style='backround:white;width:250px;height:80px;border:0;outline:0'>")
-          .appendTo($wrapper);
-
-      $("<DIV style='text-align:right'><BUTTON>Save</BUTTON><BUTTON>Cancel</BUTTON></DIV>")
-          .appendTo($wrapper);
-
-      $wrapper.find("button:first").bind("click", this.save);
-      $wrapper.find("button:last").bind("click", this.cancel);
-      $input.bind("keydown", this.handleKeyDown);
-
-      scope.position(args.position);
-      $input.focus().select();
-    };
-
-    this.handleKeyDown = function (e) {
-      if (e.which == $.ui.keyCode.ENTER && e.ctrlKey) {
-        scope.save();
-      } else if (e.which == $.ui.keyCode.ESCAPE) {
-        e.preventDefault();
-        scope.cancel();
-      } else if (e.which == $.ui.keyCode.TAB && e.shiftKey) {
-        e.preventDefault();
-        args.grid.navigatePrev();
-      } else if (e.which == $.ui.keyCode.TAB) {
-        e.preventDefault();
-        args.grid.navigateNext();
-      }
-    };
-
-    this.save = function () {
-      args.commitChanges();
-    };
-
-    this.cancel = function () {
-      $input.val(defaultValue);
-      args.cancelChanges();
-    };
-
-    this.hide = function () {
-      $wrapper.hide();
-    };
-
-    this.show = function () {
-      $wrapper.show();
-    };
-
-    this.position = function (position) {
-      $wrapper
-          .css("top", position.top - 5)
-          .css("left", position.left - 5)
-    };
-
-    this.destroy = function () {
-      $wrapper.remove();
-    };
-
-    this.focus = function () {
-      $input.focus();
-    };
-
-    this.loadValue = function (item) {
-      $input.val(defaultValue = item[args.column.field]);
-      $input.select();
-    };
-
-    this.serializeValue = function () {
-      return $input.val();
-    };
-
-    this.applyValue = function (item, state) {
-      item[args.column.field] = state;
-    };
-
-    this.isValueChanged = function () {
-      return (!($input.val() == "" && defaultValue == null)) && ($input.val() != defaultValue);
-    };
-
-    this.validate = function () {
-      return {
-        valid: true,
-        msg: null
-      };
-    };
-
-    this.init();
-  }
-})(jQuery);
+  this.init();
+}

--- a/examples/slick.compositeeditor.js
+++ b/examples/slick.compositeeditor.js
@@ -1,212 +1,211 @@
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
-  $.extend(true, window, {
-    Slick: {
-      CompositeEditor: CompositeEditor
+
+$.extend(true, window, {
+  Slick: {
+    CompositeEditor: CompositeEditor
+  }
+});
+
+
+/***
+ * A composite SlickGrid editor factory.
+ * Generates an editor that is composed of multiple editors for given columns.
+ * Individual editors are provided given containers instead of the original cell.
+ * Validation will be performed on all editors individually and the results will be aggregated into one
+ * validation result.
+ *
+ *
+ * The returned editor will have its prototype set to CompositeEditor, so you can use the "instanceof" check.
+ *
+ * NOTE:  This doesn't work for detached editors since they will be created and positioned relative to the
+ *        active cell and not the provided container.
+ *
+ * @namespace Slick
+ * @class CompositeEditor
+ * @constructor
+ * @param columns {Array} Column definitions from which editors will be pulled.
+ * @param containers {Array} Container HTMLElements in which editors will be placed.
+ * @param options {Object} Options hash:
+ *  validationFailedMsg     -   A generic failed validation message set on the aggregated validation resuls.
+ *  hide                    -   A function to be called when the grid asks the editor to hide itself.
+ *  show                    -   A function to be called when the grid asks the editor to show itself.
+ *  position                -   A function to be called when the grid asks the editor to reposition itself.
+ *  destroy                 -   A function to be called when the editor is destroyed.
+ */
+function CompositeEditor(columns, containers, options) {
+  var defaultOptions = {
+    validationFailedMsg: "Some of the fields have failed validation",
+    show: null,
+    hide: null,
+    position: null,
+    destroy: null
+  };
+
+  var noop = function () {
+  };
+
+  var firstInvalidEditor;
+
+  options = $.extend({}, defaultOptions, options);
+
+
+  function getContainerBox(i) {
+    var c = containers[i];
+    var offset = $(c).offset();
+    var w = $(c).width();
+    var h = $(c).height();
+
+    return {
+      top: offset.top,
+      left: offset.left,
+      bottom: offset.top + h,
+      right: offset.left + w,
+      width: w,
+      height: h,
+      visible: true
+    };
+  }
+
+
+  function editor(args) {
+    var editors = [];
+
+
+    function init() {
+      var newArgs = {};
+      var idx = columns.length;
+      while (idx--) {
+        if (columns[idx].editor) {
+          newArgs = $.extend({}, args);
+          newArgs.container = containers[idx];
+          newArgs.column = columns[idx];
+          newArgs.position = getContainerBox(idx);
+          newArgs.commitChanges = noop;
+          newArgs.cancelChanges = noop;
+
+          editors[idx] = new (columns[idx].editor)(newArgs);
+        }
+      }
     }
-  });
 
 
-  /***
-   * A composite SlickGrid editor factory.
-   * Generates an editor that is composed of multiple editors for given columns.
-   * Individual editors are provided given containers instead of the original cell.
-   * Validation will be performed on all editors individually and the results will be aggregated into one
-   * validation result.
-   *
-   *
-   * The returned editor will have its prototype set to CompositeEditor, so you can use the "instanceof" check.
-   *
-   * NOTE:  This doesn't work for detached editors since they will be created and positioned relative to the
-   *        active cell and not the provided container.
-   *
-   * @namespace Slick
-   * @class CompositeEditor
-   * @constructor
-   * @param columns {Array} Column definitions from which editors will be pulled.
-   * @param containers {Array} Container HTMLElements in which editors will be placed.
-   * @param options {Object} Options hash:
-   *  validationFailedMsg     -   A generic failed validation message set on the aggregated validation resuls.
-   *  hide                    -   A function to be called when the grid asks the editor to hide itself.
-   *  show                    -   A function to be called when the grid asks the editor to show itself.
-   *  position                -   A function to be called when the grid asks the editor to reposition itself.
-   *  destroy                 -   A function to be called when the editor is destroyed.
-   */
-  function CompositeEditor(columns, containers, options) {
-    var defaultOptions = {
-      validationFailedMsg: "Some of the fields have failed validation",
-      show: null,
-      hide: null,
-      position: null,
-      destroy: null
+    this.destroy = function () {
+      var idx = editors.length;
+      while (idx--) {
+        editors[idx].destroy();
+      }
+
+      options.destroy && options.destroy();
     };
 
-    var noop = function () {
+
+    this.focus = function () {
+      // if validation has failed, set the focus to the first invalid editor
+      (firstInvalidEditor || editors[0]).focus();
     };
 
-    var firstInvalidEditor;
 
-    options = $.extend({}, defaultOptions, options);
-
-
-    function getContainerBox(i) {
-      var c = containers[i];
-      var offset = $(c).offset();
-      var w = $(c).width();
-      var h = $(c).height();
-
-      return {
-        top: offset.top,
-        left: offset.left,
-        bottom: offset.top + h,
-        right: offset.left + w,
-        width: w,
-        height: h,
-        visible: true
-      };
-    }
+    this.isValueChanged = function () {
+      var idx = editors.length;
+      while (idx--) {
+        if (editors[idx].isValueChanged()) {
+          return true;
+        }
+      }
+      return false;
+    };
 
 
-    function editor(args) {
-      var editors = [];
+    this.serializeValue = function () {
+      var serializedValue = [];
+      var idx = editors.length;
+      while (idx--) {
+        serializedValue[idx] = editors[idx].serializeValue();
+      }
+      return serializedValue;
+    };
 
 
-      function init() {
-        var newArgs = {};
-        var idx = columns.length;
-        while (idx--) {
-          if (columns[idx].editor) {
-            newArgs = $.extend({}, args);
-            newArgs.container = containers[idx];
-            newArgs.column = columns[idx];
-            newArgs.position = getContainerBox(idx);
-            newArgs.commitChanges = noop;
-            newArgs.cancelChanges = noop;
+    this.applyValue = function (item, state) {
+      var idx = editors.length;
+      while (idx--) {
+        editors[idx].applyValue(item, state[idx]);
+      }
+    };
 
-            editors[idx] = new (columns[idx].editor)(newArgs);
-          }
+
+    this.loadValue = function (item) {
+      var idx = editors.length;
+      while (idx--) {
+        editors[idx].loadValue(item);
+      }
+    };
+
+
+    this.validate = function () {
+      var validationResults;
+      var errors = [];
+
+      firstInvalidEditor = null;
+
+      var idx = editors.length;
+      while (idx--) {
+        validationResults = editors[idx].validate();
+        if (!validationResults.valid) {
+          firstInvalidEditor = editors[idx];
+          errors.push({
+            index: idx,
+            editor: editors[idx],
+            container: containers[idx],
+            msg: validationResults.msg
+          });
         }
       }
 
-
-      this.destroy = function () {
-        var idx = editors.length;
-        while (idx--) {
-          editors[idx].destroy();
-        }
-
-        options.destroy && options.destroy();
-      };
-
-
-      this.focus = function () {
-        // if validation has failed, set the focus to the first invalid editor
-        (firstInvalidEditor || editors[0]).focus();
-      };
+      if (errors.length) {
+        return {
+          valid: false,
+          msg: options.validationFailedMsg,
+          errors: errors
+        };
+      } else {
+        return {
+          valid: true,
+          msg: ""
+        };
+      }
+    };
 
 
-      this.isValueChanged = function () {
-        var idx = editors.length;
-        while (idx--) {
-          if (editors[idx].isValueChanged()) {
-            return true;
-          }
-        }
-        return false;
-      };
+    this.hide = function () {
+      var idx = editors.length;
+      while (idx--) {
+        editors[idx].hide && editors[idx].hide();
+      }
+      options.hide && options.hide();
+    };
 
 
-      this.serializeValue = function () {
-        var serializedValue = [];
-        var idx = editors.length;
-        while (idx--) {
-          serializedValue[idx] = editors[idx].serializeValue();
-        }
-        return serializedValue;
-      };
+    this.show = function () {
+      var idx = editors.length;
+      while (idx--) {
+        editors[idx].show && editors[idx].show();
+      }
+      options.show && options.show();
+    };
 
 
-      this.applyValue = function (item, state) {
-        var idx = editors.length;
-        while (idx--) {
-          editors[idx].applyValue(item, state[idx]);
-        }
-      };
+    this.position = function (box) {
+      options.position && options.position(box);
+    };
 
 
-      this.loadValue = function (item) {
-        var idx = editors.length;
-        while (idx--) {
-          editors[idx].loadValue(item);
-        }
-      };
-
-
-      this.validate = function () {
-        var validationResults;
-        var errors = [];
-
-        firstInvalidEditor = null;
-
-        var idx = editors.length;
-        while (idx--) {
-          validationResults = editors[idx].validate();
-          if (!validationResults.valid) {
-            firstInvalidEditor = editors[idx];
-            errors.push({
-              index: idx,
-              editor: editors[idx],
-              container: containers[idx],
-              msg: validationResults.msg
-            });
-          }
-        }
-
-        if (errors.length) {
-          return {
-            valid: false,
-            msg: options.validationFailedMsg,
-            errors: errors
-          };
-        } else {
-          return {
-            valid: true,
-            msg: ""
-          };
-        }
-      };
-
-
-      this.hide = function () {
-        var idx = editors.length;
-        while (idx--) {
-          editors[idx].hide && editors[idx].hide();
-        }
-        options.hide && options.hide();
-      };
-
-
-      this.show = function () {
-        var idx = editors.length;
-        while (idx--) {
-          editors[idx].show && editors[idx].show();
-        }
-        options.show && options.show();
-      };
-
-
-      this.position = function (box) {
-        options.position && options.position(box);
-      };
-
-
-      init();
-    }
-
-    // so we can do "editor instanceof Slick.CompositeEditor
-    editor.prototype = this;
-
-    return editor;
+    init();
   }
-})(jQuery);
+
+  // so we can do "editor instanceof Slick.CompositeEditor
+  editor.prototype = this;
+
+  return editor;
+}

--- a/examples/slick.compositeeditor.js
+++ b/examples/slick.compositeeditor.js
@@ -1,4 +1,5 @@
-;
+var jQuery = require("jquery");
+
 (function ($) {
   $.extend(true, window, {
     Slick: {

--- a/formatters.js
+++ b/formatters.js
@@ -8,54 +8,53 @@
  * @namespace Slick
  */
 
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Formatters": {
-        "PercentComplete": PercentCompleteFormatter,
-        "PercentCompleteBar": PercentCompleteBarFormatter,
-        "YesNo": YesNoFormatter,
-        "Checkmark": CheckmarkFormatter
-      }
-    }
-  });
 
-  function PercentCompleteFormatter(row, cell, value, columnDef, dataContext) {
-    if (value == null || value === "") {
-      return "-";
-    } else if (value < 50) {
-      return "<span style='color:red;font-weight:bold;'>" + value + "%</span>";
-    } else {
-      return "<span style='color:green'>" + value + "%</span>";
+// register namespace
+$.extend(true, window, {
+  "Slick": {
+    "Formatters": {
+      "PercentComplete": PercentCompleteFormatter,
+      "PercentCompleteBar": PercentCompleteBarFormatter,
+      "YesNo": YesNoFormatter,
+      "Checkmark": CheckmarkFormatter
     }
   }
+});
 
-  function PercentCompleteBarFormatter(row, cell, value, columnDef, dataContext) {
-    if (value == null || value === "") {
-      return "";
-    }
+function PercentCompleteFormatter(row, cell, value, columnDef, dataContext) {
+  if (value == null || value === "") {
+    return "-";
+  } else if (value < 50) {
+    return "<span style='color:red;font-weight:bold;'>" + value + "%</span>";
+  } else {
+    return "<span style='color:green'>" + value + "%</span>";
+  }
+}
 
-    var color;
-
-    if (value < 30) {
-      color = "red";
-    } else if (value < 70) {
-      color = "silver";
-    } else {
-      color = "green";
-    }
-
-    return "<span class='percent-complete-bar' style='background:" + color + ";width:" + value + "%'></span>";
+function PercentCompleteBarFormatter(row, cell, value, columnDef, dataContext) {
+  if (value == null || value === "") {
+    return "";
   }
 
-  function YesNoFormatter(row, cell, value, columnDef, dataContext) {
-    return value ? "Yes" : "No";
+  var color;
+
+  if (value < 30) {
+    color = "red";
+  } else if (value < 70) {
+    color = "silver";
+  } else {
+    color = "green";
   }
 
-  function CheckmarkFormatter(row, cell, value, columnDef, dataContext) {
-    return value ? "<img src='../images/tick.png'>" : "";
-  }
-})(jQuery);
+  return "<span class='percent-complete-bar' style='background:" + color + ";width:" + value + "%'></span>";
+}
+
+function YesNoFormatter(row, cell, value, columnDef, dataContext) {
+  return value ? "Yes" : "No";
+}
+
+function CheckmarkFormatter(row, cell, value, columnDef, dataContext) {
+  return value ? "<img src='../images/tick.png'>" : "";
+}

--- a/formatters.js
+++ b/formatters.js
@@ -1,12 +1,14 @@
 /***
  * Contains basic SlickGrid formatters.
- * 
+ *
  * NOTE:  These are merely examples.  You will most likely need to implement something more
  *        robust/extensible/localizable/etc. for your use!
- * 
+ *
  * @module Formatters
  * @namespace Slick
  */
+
+var jQuery = require("jquery");
 
 (function ($) {
   // register namespace

--- a/grid.js
+++ b/grid.js
@@ -16,12 +16,7 @@
  *     and do proper cleanup.
  */
 
-var jQuery = require("jquery");
-
-// make sure required JavaScript modules are loaded
-if (typeof jQuery === "undefined") {
-  throw "SlickGrid requires jquery module to be loaded";
-}
+var $ = require("jquery");
 
 // jquery stuff loves to touch the globals
 require('./lib/jquery.event.drag-2.2');
@@ -29,790 +24,835 @@ require('./lib/jquery.event.drag-2.2');
 // for sorting
 require('./lib/jquery-ui-1.10.1.custom');
 
-if (!jQuery.fn.drag) {
+if (!$.fn.drag) {
   throw "SlickGrid requires jquery.event.drag module to be loaded";
 }
 
 var Slick = require('./core');
 
-(function ($) {
 
-  module.exports = SlickGrid;
+module.exports = SlickGrid;
 
-  // Slick.Grid
-  $.extend(true, window, {
-    Slick: {
-      Grid: SlickGrid
-    }
-  });
+// Slick.Grid
+$.extend(true, window, {
+  Slick: {
+    Grid: SlickGrid
+  }
+});
 
-  // shared across all grids on the page
-  var scrollbarDimensions;
-  var maxSupportedCssHeight;  // browser's breaking point
+// shared across all grids on the page
+var scrollbarDimensions;
+var maxSupportedCssHeight;  // browser's breaking point
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// SlickGrid class implementation (available as Slick.Grid)
+
+/**
+ * Creates a new instance of the grid.
+ * @class SlickGrid
+ * @constructor
+ * @param {Node}              container   Container node to create the grid in.
+ * @param {Array,Object}      data        An array of objects for databinding.
+ * @param {Array}             columns     An array of column definitions.
+ * @param {Object}            options     Grid options.
+ **/
+function SlickGrid(container, data, columns, options) {
+  // settings
+  var defaults = {
+    explicitInitialization: false,
+    rowHeight: 25,
+    defaultColumnWidth: 80,
+    enableAddRow: false,
+    leaveSpaceForNewRows: false,
+    editable: false,
+    autoEdit: true,
+    enableCellNavigation: true,
+    enableColumnReorder: true,
+    asyncEditorLoading: false,
+    asyncEditorLoadDelay: 100,
+    forceFitColumns: false,
+    enableAsyncPostRender: false,
+    asyncPostRenderDelay: 50,
+    autoHeight: false,
+    editorLock: Slick.GlobalEditorLock,
+    showHeaderRow: false,
+    headerRowHeight: 25,
+    showTopPanel: false,
+    topPanelHeight: 25,
+    formatterFactory: null,
+    editorFactory: null,
+    cellFlashingCssClass: "flashing",
+    selectedCellCssClass: "selected",
+    multiSelect: true,
+    enableTextSelectionOnCells: false,
+    dataItemColumnValueExtractor: null,
+    fullWidthRows: false,
+    multiColumnSort: false,
+    defaultFormatter: defaultFormatter,
+    forceSyncScrolling: false,
+    addNewRowCssClass: "new-row",
+    disableKeyHandler: false,
+    disableFocusSinkTab: false
+  };
+
+  var columnDefaults = {
+    name: "",
+    resizable: true,
+    sortable: false,
+    minWidth: 30,
+    rerenderOnResize: false,
+    headerCssClass: null,
+    defaultSortAsc: true,
+    focusable: true,
+    selectable: true
+  };
+
+  // scroller
+  var th;   // virtual height
+  var h;    // real scrollable height
+  var ph;   // page height
+  var n;    // number of pages
+  var cj;   // "jumpiness" coefficient
+
+  var page = 0;       // current page
+  var offset = 0;     // current page offset
+  var vScrollDir = 1;
+
+  // private
+  var initialized = false;
+  var $container;
+  var uid = "slickgrid_" + Math.round(1000000 * Math.random());
+  var self = this;
+  var $focusSink, $focusSink2;
+  var $headerScroller;
+  var $headers;
+  var $headerRow, $headerRowScroller, $headerRowSpacer;
+  var $topPanelScroller;
+  var $topPanel;
+  var $viewport;
+  var $canvas;
+  var $style;
+  var $boundAncestors;
+  var stylesheet, columnCssRulesL, columnCssRulesR;
+  var viewportH, viewportW;
+  var canvasWidth;
+  var viewportHasHScroll, viewportHasVScroll;
+  var headerColumnWidthDiff = 0, headerColumnHeightDiff = 0, // border+padding
+      cellWidthDiff = 0, cellHeightDiff = 0;
+  var absoluteColumnMinWidth;
+
+  var tabbingDirection = 1;
+  var activePosX;
+  var activeRow, activeCell;
+  var activeCellNode = null;
+  var currentEditor = null;
+  var serializedEditorValue;
+  var editController;
+
+  var rowsCache = {};
+  var renderedRows = 0;
+  var numVisibleRows;
+  var prevScrollTop = 0;
+  var scrollTop = 0;
+  var lastRenderedScrollTop = 0;
+  var lastRenderedScrollLeft = 0;
+  var prevScrollLeft = 0;
+  var scrollLeft = 0;
+
+  var selectionModel;
+  var selectedRows = [];
+
+  var plugins = [];
+  var cellCssClasses = {};
+
+  var columnsById = {};
+  var sortColumns = [];
+  var columnPosLeft = [];
+  var columnPosRight = [];
+
+
+  // async call handles
+  var h_editorLoader = null;
+  var h_render = null;
+  var h_postrender = null;
+  var postProcessedRows = {};
+  var postProcessToRow = null;
+  var postProcessFromRow = null;
+
+  // perf counters
+  var counter_rows_rendered = 0;
+  var counter_rows_removed = 0;
+
+  // These two variables work around a bug with inertial scrolling in Webkit/Blink on Mac.
+  // See http://crbug.com/312427.
+  var rowNodeFromLastMouseWheelEvent;  // this node must not be deleted while inertial scrolling
+  var zombieRowNodeFromLastMouseWheelEvent;  // node that was hidden instead of getting deleted
+
 
   //////////////////////////////////////////////////////////////////////////////////////////////
-  // SlickGrid class implementation (available as Slick.Grid)
+  // Initialization
 
-  /**
-   * Creates a new instance of the grid.
-   * @class SlickGrid
-   * @constructor
-   * @param {Node}              container   Container node to create the grid in.
-   * @param {Array,Object}      data        An array of objects for databinding.
-   * @param {Array}             columns     An array of column definitions.
-   * @param {Object}            options     Grid options.
-   **/
-  function SlickGrid(container, data, columns, options) {
-    // settings
-    var defaults = {
-      explicitInitialization: false,
-      rowHeight: 25,
-      defaultColumnWidth: 80,
-      enableAddRow: false,
-      leaveSpaceForNewRows: false,
-      editable: false,
-      autoEdit: true,
-      enableCellNavigation: true,
-      enableColumnReorder: true,
-      asyncEditorLoading: false,
-      asyncEditorLoadDelay: 100,
-      forceFitColumns: false,
-      enableAsyncPostRender: false,
-      asyncPostRenderDelay: 50,
-      autoHeight: false,
-      editorLock: Slick.GlobalEditorLock,
-      showHeaderRow: false,
-      headerRowHeight: 25,
-      showTopPanel: false,
-      topPanelHeight: 25,
-      formatterFactory: null,
-      editorFactory: null,
-      cellFlashingCssClass: "flashing",
-      selectedCellCssClass: "selected",
-      multiSelect: true,
-      enableTextSelectionOnCells: false,
-      dataItemColumnValueExtractor: null,
-      fullWidthRows: false,
-      multiColumnSort: false,
-      defaultFormatter: defaultFormatter,
-      forceSyncScrolling: false,
-      addNewRowCssClass: "new-row",
-      disableKeyHandler: false,
-      disableFocusSinkTab: false
+  function init() {
+    $container = $(container);
+    if ($container.length < 1) {
+      throw new Error("SlickGrid requires a valid container, " + container + " does not exist in the DOM.");
+    }
+
+    // calculate these only once and share between grid instances
+    maxSupportedCssHeight = maxSupportedCssHeight || getMaxSupportedCssHeight();
+    scrollbarDimensions = scrollbarDimensions || measureScrollbar();
+
+    options = $.extend({}, defaults, options);
+    validateAndEnforceOptions();
+    columnDefaults.width = options.defaultColumnWidth;
+
+    columnsById = {};
+    for (var i = 0; i < columns.length; i++) {
+      var m = columns[i] = $.extend({}, columnDefaults, columns[i]);
+      columnsById[m.id] = i;
+      if (m.minWidth && m.width < m.minWidth) {
+        m.width = m.minWidth;
+      }
+      if (m.maxWidth && m.width > m.maxWidth) {
+        m.width = m.maxWidth;
+      }
+    }
+
+    // validate loaded JavaScript modules against requested options
+    if (options.enableColumnReorder && !$.fn.sortable) {
+      throw new Error("SlickGrid's 'enableColumnReorder = true' option requires jquery-ui.sortable module to be loaded");
+    }
+
+    editController = {
+      "commitCurrentEdit": commitCurrentEdit,
+      "cancelCurrentEdit": cancelCurrentEdit
     };
 
-    var columnDefaults = {
-      name: "",
-      resizable: true,
-      sortable: false,
-      minWidth: 30,
-      rerenderOnResize: false,
-      headerCssClass: null,
-      defaultSortAsc: true,
-      focusable: true,
-      selectable: true
-    };
+    $container
+        .empty()
+        .css("overflow", "hidden")
+        .css("outline", 0)
+        .addClass(uid)
+        .addClass("ui-widget");
 
-    // scroller
-    var th;   // virtual height
-    var h;    // real scrollable height
-    var ph;   // page height
-    var n;    // number of pages
-    var cj;   // "jumpiness" coefficient
+    // set up a positioning container if needed
+    if (!/relative|absolute|fixed/.test($container.css("position"))) {
+      $container.css("position", "relative");
+    }
 
-    var page = 0;       // current page
-    var offset = 0;     // current page offset
-    var vScrollDir = 1;
+    $focusSink = $("<div tabIndex='0' hideFocus style='position:fixed;width:0;height:0;top:0;left:0;outline:0;'></div>").appendTo($container);
 
-    // private
-    var initialized = false;
-    var $container;
-    var uid = "slickgrid_" + Math.round(1000000 * Math.random());
-    var self = this;
-    var $focusSink, $focusSink2;
-    var $headerScroller;
-    var $headers;
-    var $headerRow, $headerRowScroller, $headerRowSpacer;
-    var $topPanelScroller;
-    var $topPanel;
-    var $viewport;
-    var $canvas;
-    var $style;
-    var $boundAncestors;
-    var stylesheet, columnCssRulesL, columnCssRulesR;
-    var viewportH, viewportW;
-    var canvasWidth;
-    var viewportHasHScroll, viewportHasVScroll;
-    var headerColumnWidthDiff = 0, headerColumnHeightDiff = 0, // border+padding
-        cellWidthDiff = 0, cellHeightDiff = 0;
-    var absoluteColumnMinWidth;
+    $headerScroller = $("<div class='slick-header ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($container);
+    $headers = $("<div class='slick-header-columns' style='left:-1000px' />").appendTo($headerScroller);
+    $headers.width(getHeadersWidth());
 
-    var tabbingDirection = 1;
-    var activePosX;
-    var activeRow, activeCell;
-    var activeCellNode = null;
-    var currentEditor = null;
-    var serializedEditorValue;
-    var editController;
+    $headerRowScroller = $("<div class='slick-headerrow ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($container);
+    $headerRow = $("<div class='slick-headerrow-columns' />").appendTo($headerRowScroller);
+    $headerRowSpacer = $("<div style='display:block;height:1px;position:absolute;top:0;left:0;'></div>")
+        .css("width", getCanvasWidth() + scrollbarDimensions.width + "px")
+        .appendTo($headerRowScroller);
 
-    var rowsCache = {};
-    var renderedRows = 0;
-    var numVisibleRows;
-    var prevScrollTop = 0;
-    var scrollTop = 0;
-    var lastRenderedScrollTop = 0;
-    var lastRenderedScrollLeft = 0;
-    var prevScrollLeft = 0;
-    var scrollLeft = 0;
+    $topPanelScroller = $("<div class='slick-top-panel-scroller ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($container);
+    $topPanel = $("<div class='slick-top-panel' style='width:10000px' />").appendTo($topPanelScroller);
 
-    var selectionModel;
-    var selectedRows = [];
+    if (!options.showTopPanel) {
+      $topPanelScroller.hide();
+    }
 
-    var plugins = [];
-    var cellCssClasses = {};
+    if (!options.showHeaderRow) {
+      $headerRowScroller.hide();
+    }
 
-    var columnsById = {};
-    var sortColumns = [];
-    var columnPosLeft = [];
-    var columnPosRight = [];
+    $viewport = $("<div class='slick-viewport' style='width:100%;overflow:auto;outline:0;position:relative;;'>").appendTo($container);
+    $viewport.css("overflow-y", options.autoHeight ? "hidden" : "auto");
 
+    $canvas = $("<div class='grid-canvas' />").appendTo($viewport);
 
-    // async call handles
-    var h_editorLoader = null;
-    var h_render = null;
-    var h_postrender = null;
-    var postProcessedRows = {};
-    var postProcessToRow = null;
-    var postProcessFromRow = null;
+    $focusSink2 = $focusSink.clone().appendTo($container);
+    // tab is set, so remove the focus sink from the tab.
+    // leaving it turns the grid into 2 tab stops.
+    // removing it all the time breaks slick grid tab stealing.
+    if (options.disableFocusSinkTab) {
+      $focusSink2.attr("tabindex", "-1");
+    }
 
-    // perf counters
-    var counter_rows_rendered = 0;
-    var counter_rows_removed = 0;
+    if (!options.explicitInitialization) {
+      finishInitialization();
+    }
+  }
 
-    // These two variables work around a bug with inertial scrolling in Webkit/Blink on Mac.
-    // See http://crbug.com/312427.
-    var rowNodeFromLastMouseWheelEvent;  // this node must not be deleted while inertial scrolling
-    var zombieRowNodeFromLastMouseWheelEvent;  // node that was hidden instead of getting deleted
+  function finishInitialization() {
+    if (!initialized) {
+      initialized = true;
 
+      viewportW = parseFloat($.css($container[0], "width", true));
 
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    // Initialization
+      // header columns and cells may have different padding/border skewing width calculations (box-sizing, hello?)
+      // calculate the diff so we can set consistent sizes
+      measureCellPaddingAndBorder();
 
-    function init() {
-      $container = $(container);
-      if ($container.length < 1) {
-        throw new Error("SlickGrid requires a valid container, " + container + " does not exist in the DOM.");
+      // for usability reasons, all text selection in SlickGrid is disabled
+      // with the exception of input and textarea elements (selection must
+      // be enabled there so that editors work as expected); note that
+      // selection in grid cells (grid body) is already unavailable in
+      // all browsers except IE
+      disableSelection($headers); // disable all text selection in header (including input and textarea)
+
+      if (!options.enableTextSelectionOnCells) {
+        // disable text selection in grid cells except in input and textarea elements
+        // (this is IE-specific, because selectstart event will only fire in IE)
+        $viewport.bind("selectstart.ui", function (event) {
+          return $(event.target).is("input,textarea");
+        });
       }
 
-      // calculate these only once and share between grid instances
-      maxSupportedCssHeight = maxSupportedCssHeight || getMaxSupportedCssHeight();
-      scrollbarDimensions = scrollbarDimensions || measureScrollbar();
-
-      options = $.extend({}, defaults, options);
-      validateAndEnforceOptions();
-      columnDefaults.width = options.defaultColumnWidth;
-
-      columnsById = {};
-      for (var i = 0; i < columns.length; i++) {
-        var m = columns[i] = $.extend({}, columnDefaults, columns[i]);
-        columnsById[m.id] = i;
-        if (m.minWidth && m.width < m.minWidth) {
-          m.width = m.minWidth;
-        }
-        if (m.maxWidth && m.width > m.maxWidth) {
-          m.width = m.maxWidth;
-        }
-      }
-
-      // validate loaded JavaScript modules against requested options
-      if (options.enableColumnReorder && !$.fn.sortable) {
-        throw new Error("SlickGrid's 'enableColumnReorder = true' option requires jquery-ui.sortable module to be loaded");
-      }
-
-      editController = {
-        "commitCurrentEdit": commitCurrentEdit,
-        "cancelCurrentEdit": cancelCurrentEdit
-      };
+      updateColumnCaches();
+      createColumnHeaders();
+      setupColumnSort();
+      createCssRules();
+      resizeCanvas();
+      bindAncestorScrollEvents();
 
       $container
-          .empty()
-          .css("overflow", "hidden")
-          .css("outline", 0)
-          .addClass(uid)
-          .addClass("ui-widget");
-
-      // set up a positioning container if needed
-      if (!/relative|absolute|fixed/.test($container.css("position"))) {
-        $container.css("position", "relative");
+          .bind("resize.slickgrid", resizeCanvas);
+      $viewport
+          //.bind("click", handleClick)
+          .bind("scroll", handleScroll);
+      $headerScroller
+          .bind("contextmenu", handleHeaderContextMenu)
+          .bind("click", handleHeaderClick)
+          .delegate(".slick-header-column", "mouseenter", handleHeaderMouseEnter)
+          .delegate(".slick-header-column", "mouseleave", handleHeaderMouseLeave);
+      $headerRowScroller
+          .bind("scroll", handleHeaderRowScroll);
+      if (!self.getOptions().disableKeyHandler) {
+        $focusSink.add($focusSink2)
+            .bind("keydown", handleKeyDown);
+        $canvas
+            .bind("keydown", handleKeyDown)
       }
+      $canvas
+          .bind("click", handleClick)
+          .bind("dblclick", handleDblClick)
+          .bind("contextmenu", handleContextMenu)
+          .bind("draginit", handleDragInit)
+          .bind("dragstart", {distance: 3}, handleDragStart)
+          .bind("drag", handleDrag)
+          .bind("dragend", handleDragEnd)
+          .delegate(".slick-cell", "mouseenter", handleMouseEnter)
+          .delegate(".slick-cell", "mouseleave", handleMouseLeave);
 
-      $focusSink = $("<div tabIndex='0' hideFocus style='position:fixed;width:0;height:0;top:0;left:0;outline:0;'></div>").appendTo($container);
-
-      $headerScroller = $("<div class='slick-header ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($container);
-      $headers = $("<div class='slick-header-columns' style='left:-1000px' />").appendTo($headerScroller);
-      $headers.width(getHeadersWidth());
-
-      $headerRowScroller = $("<div class='slick-headerrow ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($container);
-      $headerRow = $("<div class='slick-headerrow-columns' />").appendTo($headerRowScroller);
-      $headerRowSpacer = $("<div style='display:block;height:1px;position:absolute;top:0;left:0;'></div>")
-          .css("width", getCanvasWidth() + scrollbarDimensions.width + "px")
-          .appendTo($headerRowScroller);
-
-      $topPanelScroller = $("<div class='slick-top-panel-scroller ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($container);
-      $topPanel = $("<div class='slick-top-panel' style='width:10000px' />").appendTo($topPanelScroller);
-
-      if (!options.showTopPanel) {
-        $topPanelScroller.hide();
+      // Work around http://crbug.com/312427.
+      if (navigator.userAgent.toLowerCase().match(/webkit/) &&
+          navigator.userAgent.toLowerCase().match(/macintosh/)) {
+        $canvas.bind("mousewheel", handleMouseWheel);
       }
+    }
+  }
 
-      if (!options.showHeaderRow) {
-        $headerRowScroller.hide();
+  function registerPlugin(plugin) {
+    plugins.unshift(plugin);
+    plugin.init(self);
+  }
+
+  function unregisterPlugin(plugin) {
+    for (var i = plugins.length; i >= 0; i--) {
+      if (plugins[i] === plugin) {
+        if (plugins[i].destroy) {
+          plugins[i].destroy();
+        }
+        plugins.splice(i, 1);
+        break;
       }
+    }
+  }
 
-      $viewport = $("<div class='slick-viewport' style='width:100%;overflow:auto;outline:0;position:relative;;'>").appendTo($container);
-      $viewport.css("overflow-y", options.autoHeight ? "hidden" : "auto");
-
-      $canvas = $("<div class='grid-canvas' />").appendTo($viewport);
-
-      $focusSink2 = $focusSink.clone().appendTo($container);
-      // tab is set, so remove the focus sink from the tab.
-      // leaving it turns the grid into 2 tab stops.
-      // removing it all the time breaks slick grid tab stealing.
-      if (options.disableFocusSinkTab) {
-        $focusSink2.attr("tabindex", "-1");
-      }
-
-      if (!options.explicitInitialization) {
-        finishInitialization();
+  function setSelectionModel(model) {
+    if (selectionModel) {
+      selectionModel.onSelectedRangesChanged.unsubscribe(handleSelectedRangesChanged);
+      if (selectionModel.destroy) {
+        selectionModel.destroy();
       }
     }
 
-    function finishInitialization() {
-      if (!initialized) {
-        initialized = true;
+    selectionModel = model;
+    if (selectionModel) {
+      selectionModel.init(self);
+      selectionModel.onSelectedRangesChanged.subscribe(handleSelectedRangesChanged);
+    }
+  }
 
-        viewportW = parseFloat($.css($container[0], "width", true));
+  function getSelectionModel() {
+    return selectionModel;
+  }
 
-        // header columns and cells may have different padding/border skewing width calculations (box-sizing, hello?)
-        // calculate the diff so we can set consistent sizes
-        measureCellPaddingAndBorder();
+  function getCanvasNode() {
+    return $canvas[0];
+  }
 
-        // for usability reasons, all text selection in SlickGrid is disabled
-        // with the exception of input and textarea elements (selection must
-        // be enabled there so that editors work as expected); note that
-        // selection in grid cells (grid body) is already unavailable in
-        // all browsers except IE
-        disableSelection($headers); // disable all text selection in header (including input and textarea)
+  function measureScrollbar() {
+    var $c = $("<div style='position:absolute; top:-10000px; left:-10000px; width:100px; height:100px; overflow:scroll;'></div>").appendTo("body");
+    var dim = {
+      width: $c.width() - $c[0].clientWidth,
+      height: $c.height() - $c[0].clientHeight
+    };
+    $c.remove();
+    return dim;
+  }
 
-        if (!options.enableTextSelectionOnCells) {
-          // disable text selection in grid cells except in input and textarea elements
-          // (this is IE-specific, because selectstart event will only fire in IE)
-          $viewport.bind("selectstart.ui", function (event) {
-            return $(event.target).is("input,textarea");
+  function getHeadersWidth() {
+    var headersWidth = 0;
+    for (var i = 0, ii = columns.length; i < ii; i++) {
+      var width = columns[i].width;
+      headersWidth += width;
+    }
+    headersWidth += scrollbarDimensions.width;
+    return Math.max(headersWidth, viewportW) + 1000;
+  }
+
+  function getCanvasWidth() {
+    var availableWidth = viewportHasVScroll ? viewportW - scrollbarDimensions.width : viewportW;
+    var rowWidth = 0;
+    var i = columns.length;
+    while (i--) {
+      rowWidth += columns[i].width;
+    }
+    return options.fullWidthRows ? Math.max(rowWidth, availableWidth) : rowWidth;
+  }
+
+  function updateCanvasWidth(forceColumnWidthsUpdate) {
+    var oldCanvasWidth = canvasWidth;
+    canvasWidth = getCanvasWidth();
+
+    if (canvasWidth != oldCanvasWidth) {
+      $canvas.width(canvasWidth);
+      $headerRow.width(canvasWidth);
+      $headers.width(getHeadersWidth());
+      viewportHasHScroll = (canvasWidth > viewportW - scrollbarDimensions.width);
+    }
+
+    $headerRowSpacer.width(canvasWidth + (viewportHasVScroll ? scrollbarDimensions.width : 0));
+
+    if (canvasWidth != oldCanvasWidth || forceColumnWidthsUpdate) {
+      applyColumnWidths();
+    }
+  }
+
+  function disableSelection($target) {
+    if ($target && $target.jquery) {
+      $target
+          .attr("unselectable", "on")
+          .css("MozUserSelect", "none")
+          .bind("selectstart.ui", function () {
+            return false;
+          }); // from jquery:ui.core.js 1.7.2
+    }
+  }
+
+  function getMaxSupportedCssHeight() {
+    var supportedHeight = 1000000;
+    // FF reports the height back but still renders blank after ~6M px
+    var testUpTo = navigator.userAgent.toLowerCase().match(/firefox/) ? 6000000 : 1000000000;
+    var div = $("<div style='display:none' />").appendTo(document.body);
+
+    while (true) {
+      var test = supportedHeight * 2;
+      div.css("height", test);
+      if (test > testUpTo || div.height() !== test) {
+        break;
+      } else {
+        supportedHeight = test;
+      }
+    }
+
+    div.remove();
+    return supportedHeight;
+  }
+
+  // TODO:  this is static.  need to handle page mutation.
+  function bindAncestorScrollEvents() {
+    var elem = $canvas[0];
+    while ((elem = elem.parentNode) != document.body && elem != null) {
+      // bind to scroll containers only
+      if (elem == $viewport[0] || elem.scrollWidth != elem.clientWidth || elem.scrollHeight != elem.clientHeight) {
+        var $elem = $(elem);
+        if (!$boundAncestors) {
+          $boundAncestors = $elem;
+        } else {
+          $boundAncestors = $boundAncestors.add($elem);
+        }
+        $elem.bind("scroll." + uid, handleActiveCellPositionChange);
+      }
+    }
+  }
+
+  function unbindAncestorScrollEvents() {
+    if (!$boundAncestors) {
+      return;
+    }
+    $boundAncestors.unbind("scroll." + uid);
+    $boundAncestors = null;
+  }
+
+  function updateColumnHeader(columnId, title, toolTip) {
+    if (!initialized) { return; }
+    var idx = getColumnIndex(columnId);
+    if (idx == null) {
+      return;
+    }
+
+    var columnDef = columns[idx];
+    var $header = $headers.children().eq(idx);
+    if ($header) {
+      if (title !== undefined) {
+        columns[idx].name = title;
+      }
+      if (toolTip !== undefined) {
+        columns[idx].toolTip = toolTip;
+      }
+
+      trigger(self.onBeforeHeaderCellDestroy, {
+        "node": $header[0],
+        "column": columnDef
+      });
+
+      $header
+          .attr("title", toolTip || "")
+          .children().eq(0).html(title);
+
+      trigger(self.onHeaderCellRendered, {
+        "node": $header[0],
+        "column": columnDef
+      });
+    }
+  }
+
+  function getHeaderRow() {
+    return $headerRow[0];
+  }
+
+  function getHeaderRowColumn(columnId) {
+    var idx = getColumnIndex(columnId);
+    var $header = $headerRow.children().eq(idx);
+    return $header && $header[0];
+  }
+
+  function createColumnHeaders() {
+    function onMouseEnter() {
+      $(this).addClass("ui-state-hover");
+    }
+
+    function onMouseLeave() {
+      $(this).removeClass("ui-state-hover");
+    }
+
+    $headers.find(".slick-header-column")
+      .each(function() {
+        var columnDef = $(this).data("column");
+        if (columnDef) {
+          trigger(self.onBeforeHeaderCellDestroy, {
+            "node": this,
+            "column": columnDef
           });
         }
+      });
+    $headers.empty();
+    $headers.width(getHeadersWidth());
 
-        updateColumnCaches();
-        createColumnHeaders();
-        setupColumnSort();
-        createCssRules();
-        resizeCanvas();
-        bindAncestorScrollEvents();
-
-        $container
-            .bind("resize.slickgrid", resizeCanvas);
-        $viewport
-            //.bind("click", handleClick)
-            .bind("scroll", handleScroll);
-        $headerScroller
-            .bind("contextmenu", handleHeaderContextMenu)
-            .bind("click", handleHeaderClick)
-            .delegate(".slick-header-column", "mouseenter", handleHeaderMouseEnter)
-            .delegate(".slick-header-column", "mouseleave", handleHeaderMouseLeave);
-        $headerRowScroller
-            .bind("scroll", handleHeaderRowScroll);
-        if (!self.getOptions().disableKeyHandler) {
-          $focusSink.add($focusSink2)
-              .bind("keydown", handleKeyDown);
-          $canvas
-              .bind("keydown", handleKeyDown)
+    $headerRow.find(".slick-headerrow-column")
+      .each(function() {
+        var columnDef = $(this).data("column");
+        if (columnDef) {
+          trigger(self.onBeforeHeaderRowCellDestroy, {
+            "node": this,
+            "column": columnDef
+          });
         }
-        $canvas
-            .bind("click", handleClick)
-            .bind("dblclick", handleDblClick)
-            .bind("contextmenu", handleContextMenu)
-            .bind("draginit", handleDragInit)
-            .bind("dragstart", {distance: 3}, handleDragStart)
-            .bind("drag", handleDrag)
-            .bind("dragend", handleDragEnd)
-            .delegate(".slick-cell", "mouseenter", handleMouseEnter)
-            .delegate(".slick-cell", "mouseleave", handleMouseLeave);
+      });
+    $headerRow.empty();
 
-        // Work around http://crbug.com/312427.
-        if (navigator.userAgent.toLowerCase().match(/webkit/) &&
-            navigator.userAgent.toLowerCase().match(/macintosh/)) {
-          $canvas.bind("mousewheel", handleMouseWheel);
-        }
-      }
-    }
+    for (var i = 0; i < columns.length; i++) {
+      var m = columns[i];
 
-    function registerPlugin(plugin) {
-      plugins.unshift(plugin);
-      plugin.init(self);
-    }
+      var header = $("<div class='ui-state-default slick-header-column' />")
+          .html("<span class='slick-column-name'>" + m.name + "</span>")
+          .width(m.width - headerColumnWidthDiff)
+          .attr("id", "" + uid + m.id)
+          .attr("title", m.toolTip || "")
+          .data("column", m)
+          .addClass(m.headerCssClass || "")
+          .appendTo($headers);
 
-    function unregisterPlugin(plugin) {
-      for (var i = plugins.length; i >= 0; i--) {
-        if (plugins[i] === plugin) {
-          if (plugins[i].destroy) {
-            plugins[i].destroy();
-          }
-          plugins.splice(i, 1);
-          break;
-        }
-      }
-    }
-
-    function setSelectionModel(model) {
-      if (selectionModel) {
-        selectionModel.onSelectedRangesChanged.unsubscribe(handleSelectedRangesChanged);
-        if (selectionModel.destroy) {
-          selectionModel.destroy();
-        }
+      if (options.enableColumnReorder || m.sortable) {
+        header
+          .on('mouseenter', onMouseEnter)
+          .on('mouseleave', onMouseLeave);
       }
 
-      selectionModel = model;
-      if (selectionModel) {
-        selectionModel.init(self);
-        selectionModel.onSelectedRangesChanged.subscribe(handleSelectedRangesChanged);
-      }
-    }
-
-    function getSelectionModel() {
-      return selectionModel;
-    }
-
-    function getCanvasNode() {
-      return $canvas[0];
-    }
-
-    function measureScrollbar() {
-      var $c = $("<div style='position:absolute; top:-10000px; left:-10000px; width:100px; height:100px; overflow:scroll;'></div>").appendTo("body");
-      var dim = {
-        width: $c.width() - $c[0].clientWidth,
-        height: $c.height() - $c[0].clientHeight
-      };
-      $c.remove();
-      return dim;
-    }
-
-    function getHeadersWidth() {
-      var headersWidth = 0;
-      for (var i = 0, ii = columns.length; i < ii; i++) {
-        var width = columns[i].width;
-        headersWidth += width;
-      }
-      headersWidth += scrollbarDimensions.width;
-      return Math.max(headersWidth, viewportW) + 1000;
-    }
-
-    function getCanvasWidth() {
-      var availableWidth = viewportHasVScroll ? viewportW - scrollbarDimensions.width : viewportW;
-      var rowWidth = 0;
-      var i = columns.length;
-      while (i--) {
-        rowWidth += columns[i].width;
-      }
-      return options.fullWidthRows ? Math.max(rowWidth, availableWidth) : rowWidth;
-    }
-
-    function updateCanvasWidth(forceColumnWidthsUpdate) {
-      var oldCanvasWidth = canvasWidth;
-      canvasWidth = getCanvasWidth();
-
-      if (canvasWidth != oldCanvasWidth) {
-        $canvas.width(canvasWidth);
-        $headerRow.width(canvasWidth);
-        $headers.width(getHeadersWidth());
-        viewportHasHScroll = (canvasWidth > viewportW - scrollbarDimensions.width);
+      if (m.sortable) {
+        header.addClass("slick-header-sortable");
+        header.append("<span class='slick-sort-indicator' />");
       }
 
-      $headerRowSpacer.width(canvasWidth + (viewportHasVScroll ? scrollbarDimensions.width : 0));
+      trigger(self.onHeaderCellRendered, {
+        "node": header[0],
+        "column": m
+      });
 
-      if (canvasWidth != oldCanvasWidth || forceColumnWidthsUpdate) {
-        applyColumnWidths();
-      }
-    }
-
-    function disableSelection($target) {
-      if ($target && $target.jquery) {
-        $target
-            .attr("unselectable", "on")
-            .css("MozUserSelect", "none")
-            .bind("selectstart.ui", function () {
-              return false;
-            }); // from jquery:ui.core.js 1.7.2
-      }
-    }
-
-    function getMaxSupportedCssHeight() {
-      var supportedHeight = 1000000;
-      // FF reports the height back but still renders blank after ~6M px
-      var testUpTo = navigator.userAgent.toLowerCase().match(/firefox/) ? 6000000 : 1000000000;
-      var div = $("<div style='display:none' />").appendTo(document.body);
-
-      while (true) {
-        var test = supportedHeight * 2;
-        div.css("height", test);
-        if (test > testUpTo || div.height() !== test) {
-          break;
-        } else {
-          supportedHeight = test;
-        }
-      }
-
-      div.remove();
-      return supportedHeight;
-    }
-
-    // TODO:  this is static.  need to handle page mutation.
-    function bindAncestorScrollEvents() {
-      var elem = $canvas[0];
-      while ((elem = elem.parentNode) != document.body && elem != null) {
-        // bind to scroll containers only
-        if (elem == $viewport[0] || elem.scrollWidth != elem.clientWidth || elem.scrollHeight != elem.clientHeight) {
-          var $elem = $(elem);
-          if (!$boundAncestors) {
-            $boundAncestors = $elem;
-          } else {
-            $boundAncestors = $boundAncestors.add($elem);
-          }
-          $elem.bind("scroll." + uid, handleActiveCellPositionChange);
-        }
-      }
-    }
-
-    function unbindAncestorScrollEvents() {
-      if (!$boundAncestors) {
-        return;
-      }
-      $boundAncestors.unbind("scroll." + uid);
-      $boundAncestors = null;
-    }
-
-    function updateColumnHeader(columnId, title, toolTip) {
-      if (!initialized) { return; }
-      var idx = getColumnIndex(columnId);
-      if (idx == null) {
-        return;
-      }
-
-      var columnDef = columns[idx];
-      var $header = $headers.children().eq(idx);
-      if ($header) {
-        if (title !== undefined) {
-          columns[idx].name = title;
-        }
-        if (toolTip !== undefined) {
-          columns[idx].toolTip = toolTip;
-        }
-
-        trigger(self.onBeforeHeaderCellDestroy, {
-          "node": $header[0],
-          "column": columnDef
-        });
-
-        $header
-            .attr("title", toolTip || "")
-            .children().eq(0).html(title);
-
-        trigger(self.onHeaderCellRendered, {
-          "node": $header[0],
-          "column": columnDef
-        });
-      }
-    }
-
-    function getHeaderRow() {
-      return $headerRow[0];
-    }
-
-    function getHeaderRowColumn(columnId) {
-      var idx = getColumnIndex(columnId);
-      var $header = $headerRow.children().eq(idx);
-      return $header && $header[0];
-    }
-
-    function createColumnHeaders() {
-      function onMouseEnter() {
-        $(this).addClass("ui-state-hover");
-      }
-
-      function onMouseLeave() {
-        $(this).removeClass("ui-state-hover");
-      }
-
-      $headers.find(".slick-header-column")
-        .each(function() {
-          var columnDef = $(this).data("column");
-          if (columnDef) {
-            trigger(self.onBeforeHeaderCellDestroy, {
-              "node": this,
-              "column": columnDef
-            });
-          }
-        });
-      $headers.empty();
-      $headers.width(getHeadersWidth());
-
-      $headerRow.find(".slick-headerrow-column")
-        .each(function() {
-          var columnDef = $(this).data("column");
-          if (columnDef) {
-            trigger(self.onBeforeHeaderRowCellDestroy, {
-              "node": this,
-              "column": columnDef
-            });
-          }
-        });
-      $headerRow.empty();
-
-      for (var i = 0; i < columns.length; i++) {
-        var m = columns[i];
-
-        var header = $("<div class='ui-state-default slick-header-column' />")
-            .html("<span class='slick-column-name'>" + m.name + "</span>")
-            .width(m.width - headerColumnWidthDiff)
-            .attr("id", "" + uid + m.id)
-            .attr("title", m.toolTip || "")
+      if (options.showHeaderRow) {
+        var headerRowCell = $("<div class='ui-state-default slick-headerrow-column l" + i + " r" + i + "'></div>")
             .data("column", m)
-            .addClass(m.headerCssClass || "")
-            .appendTo($headers);
+            .appendTo($headerRow);
 
-        if (options.enableColumnReorder || m.sortable) {
-          header
-            .on('mouseenter', onMouseEnter)
-            .on('mouseleave', onMouseLeave);
-        }
-
-        if (m.sortable) {
-          header.addClass("slick-header-sortable");
-          header.append("<span class='slick-sort-indicator' />");
-        }
-
-        trigger(self.onHeaderCellRendered, {
-          "node": header[0],
+        trigger(self.onHeaderRowCellRendered, {
+          "node": headerRowCell[0],
           "column": m
         });
-
-        if (options.showHeaderRow) {
-          var headerRowCell = $("<div class='ui-state-default slick-headerrow-column l" + i + " r" + i + "'></div>")
-              .data("column", m)
-              .appendTo($headerRow);
-
-          trigger(self.onHeaderRowCellRendered, {
-            "node": headerRowCell[0],
-            "column": m
-          });
-        }
-      }
-
-      setSortColumns(sortColumns);
-      setupColumnResize();
-      if (options.enableColumnReorder) {
-        setupColumnReorder();
       }
     }
 
-    function setupColumnSort() {
-      $headers.click(function (e) {
-        // temporary workaround for a bug in jQuery 1.7.1 (http://bugs.jquery.com/ticket/11328)
-        e.metaKey = e.metaKey || e.ctrlKey;
-
-        if ($(e.target).hasClass("slick-resizable-handle")) {
-          return;
-        }
-
-        var $col = $(e.target).closest(".slick-header-column");
-        if (!$col.length) {
-          return;
-        }
-
-        var column = $col.data("column");
-        if (column.sortable) {
-          if (!getEditorLock().commitCurrentEdit()) {
-            return;
-          }
-
-          var sortOpts = null;
-          var i = 0;
-          for (; i < sortColumns.length; i++) {
-            if (sortColumns[i].columnId == column.id) {
-              sortOpts = sortColumns[i];
-              sortOpts.sortAsc = !sortOpts.sortAsc;
-              break;
-            }
-          }
-
-          if (e.metaKey && options.multiColumnSort) {
-            if (sortOpts) {
-              sortColumns.splice(i, 1);
-            }
-          }
-          else {
-            if ((!e.shiftKey && !e.metaKey) || !options.multiColumnSort) {
-              sortColumns = [];
-            }
-
-            if (!sortOpts) {
-              sortOpts = { columnId: column.id, sortAsc: column.defaultSortAsc };
-              sortColumns.push(sortOpts);
-            } else if (sortColumns.length == 0) {
-              sortColumns.push(sortOpts);
-            }
-          }
-
-          setSortColumns(sortColumns);
-
-          if (!options.multiColumnSort) {
-            trigger(self.onSort, {
-              multiColumnSort: false,
-              sortCol: column,
-              sortAsc: sortOpts.sortAsc}, e);
-          } else {
-            trigger(self.onSort, {
-              multiColumnSort: true,
-              sortCols: $.map(sortColumns, function(col) {
-                return {sortCol: columns[getColumnIndex(col.columnId)], sortAsc: col.sortAsc };
-              })}, e);
-          }
-        }
-      });
+    setSortColumns(sortColumns);
+    setupColumnResize();
+    if (options.enableColumnReorder) {
+      setupColumnReorder();
     }
+  }
 
-    function setupColumnReorder() {
-      $headers.filter(":ui-sortable").sortable("destroy");
-      $headers.sortable({
-        containment: "parent",
-        distance: 3,
-        axis: "x",
-        cursor: "default",
-        tolerance: "intersection",
-        helper: "clone",
-        placeholder: "slick-sortable-placeholder ui-state-default slick-header-column",
-        start: function (e, ui) {
-          ui.placeholder.width(ui.helper.outerWidth() - headerColumnWidthDiff);
-          $(ui.helper).addClass("slick-header-column-active");
-        },
-        beforeStop: function (e, ui) {
-          $(ui.helper).removeClass("slick-header-column-active");
-        },
-        stop: function (e) {
-          if (!getEditorLock().commitCurrentEdit()) {
-            $(this).sortable("cancel");
-            return;
-          }
+  function setupColumnSort() {
+    $headers.click(function (e) {
+      // temporary workaround for a bug in jQuery 1.7.1 (http://bugs.jquery.com/ticket/11328)
+      e.metaKey = e.metaKey || e.ctrlKey;
 
-          var reorderedIds = $headers.sortable("toArray");
-          var reorderedColumns = [];
-          for (var i = 0; i < reorderedIds.length; i++) {
-            reorderedColumns.push(columns[getColumnIndex(reorderedIds[i].replace(uid, ""))]);
-          }
-          setColumns(reorderedColumns);
-
-          trigger(self.onColumnsReordered, {});
-          e.stopPropagation();
-          setupColumnResize();
-        }
-      });
-    }
-
-    function setupColumnResize() {
-      var $col, j, c, pageX, columnElements, minPageX, maxPageX, firstResizable, lastResizable;
-      columnElements = $headers.children();
-      columnElements.find(".slick-resizable-handle").remove();
-      columnElements.each(function (i, e) {
-        if (columns[i].resizable) {
-          if (firstResizable === undefined) {
-            firstResizable = i;
-          }
-          lastResizable = i;
-        }
-      });
-      if (firstResizable === undefined) {
+      if ($(e.target).hasClass("slick-resizable-handle")) {
         return;
       }
-      columnElements.each(function (i, e) {
-        if (i < firstResizable || (options.forceFitColumns && i >= lastResizable)) {
+
+      var $col = $(e.target).closest(".slick-header-column");
+      if (!$col.length) {
+        return;
+      }
+
+      var column = $col.data("column");
+      if (column.sortable) {
+        if (!getEditorLock().commitCurrentEdit()) {
           return;
         }
-        $col = $(e);
-        $("<div class='slick-resizable-handle' />")
-            .appendTo(e)
-            .bind("dragstart", function (e, dd) {
-              if (!getEditorLock().commitCurrentEdit()) {
-                return false;
+
+        var sortOpts = null;
+        var i = 0;
+        for (; i < sortColumns.length; i++) {
+          if (sortColumns[i].columnId == column.id) {
+            sortOpts = sortColumns[i];
+            sortOpts.sortAsc = !sortOpts.sortAsc;
+            break;
+          }
+        }
+
+        if (e.metaKey && options.multiColumnSort) {
+          if (sortOpts) {
+            sortColumns.splice(i, 1);
+          }
+        }
+        else {
+          if ((!e.shiftKey && !e.metaKey) || !options.multiColumnSort) {
+            sortColumns = [];
+          }
+
+          if (!sortOpts) {
+            sortOpts = { columnId: column.id, sortAsc: column.defaultSortAsc };
+            sortColumns.push(sortOpts);
+          } else if (sortColumns.length == 0) {
+            sortColumns.push(sortOpts);
+          }
+        }
+
+        setSortColumns(sortColumns);
+
+        if (!options.multiColumnSort) {
+          trigger(self.onSort, {
+            multiColumnSort: false,
+            sortCol: column,
+            sortAsc: sortOpts.sortAsc}, e);
+        } else {
+          trigger(self.onSort, {
+            multiColumnSort: true,
+            sortCols: $.map(sortColumns, function(col) {
+              return {sortCol: columns[getColumnIndex(col.columnId)], sortAsc: col.sortAsc };
+            })}, e);
+        }
+      }
+    });
+  }
+
+  function setupColumnReorder() {
+    $headers.filter(":ui-sortable").sortable("destroy");
+    $headers.sortable({
+      containment: "parent",
+      distance: 3,
+      axis: "x",
+      cursor: "default",
+      tolerance: "intersection",
+      helper: "clone",
+      placeholder: "slick-sortable-placeholder ui-state-default slick-header-column",
+      start: function (e, ui) {
+        ui.placeholder.width(ui.helper.outerWidth() - headerColumnWidthDiff);
+        $(ui.helper).addClass("slick-header-column-active");
+      },
+      beforeStop: function (e, ui) {
+        $(ui.helper).removeClass("slick-header-column-active");
+      },
+      stop: function (e) {
+        if (!getEditorLock().commitCurrentEdit()) {
+          $(this).sortable("cancel");
+          return;
+        }
+
+        var reorderedIds = $headers.sortable("toArray");
+        var reorderedColumns = [];
+        for (var i = 0; i < reorderedIds.length; i++) {
+          reorderedColumns.push(columns[getColumnIndex(reorderedIds[i].replace(uid, ""))]);
+        }
+        setColumns(reorderedColumns);
+
+        trigger(self.onColumnsReordered, {});
+        e.stopPropagation();
+        setupColumnResize();
+      }
+    });
+  }
+
+  function setupColumnResize() {
+    var $col, j, c, pageX, columnElements, minPageX, maxPageX, firstResizable, lastResizable;
+    columnElements = $headers.children();
+    columnElements.find(".slick-resizable-handle").remove();
+    columnElements.each(function (i, e) {
+      if (columns[i].resizable) {
+        if (firstResizable === undefined) {
+          firstResizable = i;
+        }
+        lastResizable = i;
+      }
+    });
+    if (firstResizable === undefined) {
+      return;
+    }
+    columnElements.each(function (i, e) {
+      if (i < firstResizable || (options.forceFitColumns && i >= lastResizable)) {
+        return;
+      }
+      $col = $(e);
+      $("<div class='slick-resizable-handle' />")
+          .appendTo(e)
+          .bind("dragstart", function (e, dd) {
+            if (!getEditorLock().commitCurrentEdit()) {
+              return false;
+            }
+            pageX = e.pageX;
+            $(this).parent().addClass("slick-header-column-active");
+            var shrinkLeewayOnRight = null, stretchLeewayOnRight = null;
+            // lock each column's width option to current width
+            columnElements.each(function (i, e) {
+              columns[i].previousWidth = $(e).outerWidth();
+            });
+            if (options.forceFitColumns) {
+              shrinkLeewayOnRight = 0;
+              stretchLeewayOnRight = 0;
+              // colums on right affect maxPageX/minPageX
+              for (j = i + 1; j < columnElements.length; j++) {
+                c = columns[j];
+                if (c.resizable) {
+                  if (stretchLeewayOnRight !== null) {
+                    if (c.maxWidth) {
+                      stretchLeewayOnRight += c.maxWidth - c.previousWidth;
+                    } else {
+                      stretchLeewayOnRight = null;
+                    }
+                  }
+                  shrinkLeewayOnRight += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
+                }
               }
-              pageX = e.pageX;
-              $(this).parent().addClass("slick-header-column-active");
-              var shrinkLeewayOnRight = null, stretchLeewayOnRight = null;
-              // lock each column's width option to current width
-              columnElements.each(function (i, e) {
-                columns[i].previousWidth = $(e).outerWidth();
-              });
+            }
+            var shrinkLeewayOnLeft = 0, stretchLeewayOnLeft = 0;
+            for (j = 0; j <= i; j++) {
+              // columns on left only affect minPageX
+              c = columns[j];
+              if (c.resizable) {
+                if (stretchLeewayOnLeft !== null) {
+                  if (c.maxWidth) {
+                    stretchLeewayOnLeft += c.maxWidth - c.previousWidth;
+                  } else {
+                    stretchLeewayOnLeft = null;
+                  }
+                }
+                shrinkLeewayOnLeft += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
+              }
+            }
+            if (shrinkLeewayOnRight === null) {
+              shrinkLeewayOnRight = 100000;
+            }
+            if (shrinkLeewayOnLeft === null) {
+              shrinkLeewayOnLeft = 100000;
+            }
+            if (stretchLeewayOnRight === null) {
+              stretchLeewayOnRight = 100000;
+            }
+            if (stretchLeewayOnLeft === null) {
+              stretchLeewayOnLeft = 100000;
+            }
+            maxPageX = pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft);
+            minPageX = pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight);
+          })
+          .bind("drag", function (e, dd) {
+            var actualMinWidth, d = Math.min(maxPageX, Math.max(minPageX, e.pageX)) - pageX, x;
+            if (d < 0) { // shrink column
+              x = d;
+              for (j = i; j >= 0; j--) {
+                c = columns[j];
+                if (c.resizable) {
+                  actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
+                  if (x && c.previousWidth + x < actualMinWidth) {
+                    x += c.previousWidth - actualMinWidth;
+                    c.width = actualMinWidth;
+                  } else {
+                    c.width = c.previousWidth + x;
+                    x = 0;
+                  }
+                }
+              }
+
               if (options.forceFitColumns) {
-                shrinkLeewayOnRight = 0;
-                stretchLeewayOnRight = 0;
-                // colums on right affect maxPageX/minPageX
+                x = -d;
                 for (j = i + 1; j < columnElements.length; j++) {
                   c = columns[j];
                   if (c.resizable) {
-                    if (stretchLeewayOnRight !== null) {
-                      if (c.maxWidth) {
-                        stretchLeewayOnRight += c.maxWidth - c.previousWidth;
-                      } else {
-                        stretchLeewayOnRight = null;
-                      }
+                    if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
+                      x -= c.maxWidth - c.previousWidth;
+                      c.width = c.maxWidth;
+                    } else {
+                      c.width = c.previousWidth + x;
+                      x = 0;
                     }
-                    shrinkLeewayOnRight += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
                   }
                 }
               }
-              var shrinkLeewayOnLeft = 0, stretchLeewayOnLeft = 0;
-              for (j = 0; j <= i; j++) {
-                // columns on left only affect minPageX
+            } else { // stretch column
+              x = d;
+              for (j = i; j >= 0; j--) {
                 c = columns[j];
                 if (c.resizable) {
-                  if (stretchLeewayOnLeft !== null) {
-                    if (c.maxWidth) {
-                      stretchLeewayOnLeft += c.maxWidth - c.previousWidth;
-                    } else {
-                      stretchLeewayOnLeft = null;
-                    }
+                  if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
+                    x -= c.maxWidth - c.previousWidth;
+                    c.width = c.maxWidth;
+                  } else {
+                    c.width = c.previousWidth + x;
+                    x = 0;
                   }
-                  shrinkLeewayOnLeft += c.previousWidth - Math.max(c.minWidth || 0, absoluteColumnMinWidth);
                 }
               }
-              if (shrinkLeewayOnRight === null) {
-                shrinkLeewayOnRight = 100000;
-              }
-              if (shrinkLeewayOnLeft === null) {
-                shrinkLeewayOnLeft = 100000;
-              }
-              if (stretchLeewayOnRight === null) {
-                stretchLeewayOnRight = 100000;
-              }
-              if (stretchLeewayOnLeft === null) {
-                stretchLeewayOnLeft = 100000;
-              }
-              maxPageX = pageX + Math.min(shrinkLeewayOnRight, stretchLeewayOnLeft);
-              minPageX = pageX - Math.min(shrinkLeewayOnLeft, stretchLeewayOnRight);
-            })
-            .bind("drag", function (e, dd) {
-              var actualMinWidth, d = Math.min(maxPageX, Math.max(minPageX, e.pageX)) - pageX, x;
-              if (d < 0) { // shrink column
-                x = d;
-                for (j = i; j >= 0; j--) {
+
+              if (options.forceFitColumns) {
+                x = -d;
+                for (j = i + 1; j < columnElements.length; j++) {
                   c = columns[j];
                   if (c.resizable) {
                     actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
@@ -825,2616 +865,2569 @@ var Slick = require('./core');
                     }
                   }
                 }
-
-                if (options.forceFitColumns) {
-                  x = -d;
-                  for (j = i + 1; j < columnElements.length; j++) {
-                    c = columns[j];
-                    if (c.resizable) {
-                      if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
-                        x -= c.maxWidth - c.previousWidth;
-                        c.width = c.maxWidth;
-                      } else {
-                        c.width = c.previousWidth + x;
-                        x = 0;
-                      }
-                    }
-                  }
-                }
-              } else { // stretch column
-                x = d;
-                for (j = i; j >= 0; j--) {
-                  c = columns[j];
-                  if (c.resizable) {
-                    if (x && c.maxWidth && (c.maxWidth - c.previousWidth < x)) {
-                      x -= c.maxWidth - c.previousWidth;
-                      c.width = c.maxWidth;
-                    } else {
-                      c.width = c.previousWidth + x;
-                      x = 0;
-                    }
-                  }
-                }
-
-                if (options.forceFitColumns) {
-                  x = -d;
-                  for (j = i + 1; j < columnElements.length; j++) {
-                    c = columns[j];
-                    if (c.resizable) {
-                      actualMinWidth = Math.max(c.minWidth || 0, absoluteColumnMinWidth);
-                      if (x && c.previousWidth + x < actualMinWidth) {
-                        x += c.previousWidth - actualMinWidth;
-                        c.width = actualMinWidth;
-                      } else {
-                        c.width = c.previousWidth + x;
-                        x = 0;
-                      }
-                    }
-                  }
-                }
               }
-              applyColumnHeaderWidths();
-              if (options.syncColumnCellResize) {
-                applyColumnWidths();
-              }
-            })
-            .bind("dragend", function (e, dd) {
-              var newWidth;
-              $(this).parent().removeClass("slick-header-column-active");
-              for (j = 0; j < columnElements.length; j++) {
-                c = columns[j];
-                newWidth = $(columnElements[j]).outerWidth();
-
-                if (c.previousWidth !== newWidth && c.rerenderOnResize) {
-                  invalidateAllRows();
-                }
-              }
-              updateCanvasWidth(true);
-              render();
-              trigger(self.onColumnsResized, {});
-            });
-      });
-    }
-
-    function getVBoxDelta($el) {
-      var p = ["borderTopWidth", "borderBottomWidth", "paddingTop", "paddingBottom"];
-      var delta = 0;
-      $.each(p, function (n, val) {
-        delta += parseFloat($el.css(val)) || 0;
-      });
-      return delta;
-    }
-
-    function measureCellPaddingAndBorder() {
-      var el;
-      var h = ["borderLeftWidth", "borderRightWidth", "paddingLeft", "paddingRight"];
-      var v = ["borderTopWidth", "borderBottomWidth", "paddingTop", "paddingBottom"];
-
-      el = $("<div class='ui-state-default slick-header-column' style='visibility:hidden'>-</div>").appendTo($headers);
-      headerColumnWidthDiff = headerColumnHeightDiff = 0;
-      if (el.css("box-sizing") != "border-box" && el.css("-moz-box-sizing") != "border-box" && el.css("-webkit-box-sizing") != "border-box") {
-        $.each(h, function (n, val) {
-          headerColumnWidthDiff += parseFloat(el.css(val)) || 0;
-        });
-        $.each(v, function (n, val) {
-          headerColumnHeightDiff += parseFloat(el.css(val)) || 0;
-        });
-      }
-      el.remove();
-
-      var r = $("<div class='slick-row' />").appendTo($canvas);
-      el = $("<div class='slick-cell' id='' style='visibility:hidden'>-</div>").appendTo(r);
-      cellWidthDiff = cellHeightDiff = 0;
-      if (el.css("box-sizing") != "border-box" && el.css("-moz-box-sizing") != "border-box" && el.css("-webkit-box-sizing") != "border-box") {
-        $.each(h, function (n, val) {
-          cellWidthDiff += parseFloat(el.css(val)) || 0;
-        });
-        $.each(v, function (n, val) {
-          cellHeightDiff += parseFloat(el.css(val)) || 0;
-        });
-      }
-      r.remove();
-
-      absoluteColumnMinWidth = Math.max(headerColumnWidthDiff, cellWidthDiff);
-    }
-
-    function createCssRules() {
-      $style = $("<style type='text/css' rel='stylesheet' />").appendTo($("head"));
-      var rowHeight = (options.rowHeight - cellHeightDiff);
-      var rules = [
-        "." + uid + " .slick-header-column { left: 1000px; }",
-        "." + uid + " .slick-top-panel { height:" + options.topPanelHeight + "px; }",
-        "." + uid + " .slick-headerrow-columns { height:" + options.headerRowHeight + "px; }",
-        "." + uid + " .slick-cell { height:" + rowHeight + "px; }",
-        "." + uid + " .slick-row { height:" + options.rowHeight + "px; }"
-      ];
-
-      for (var i = 0; i < columns.length; i++) {
-        rules.push("." + uid + " .l" + i + " { }");
-        rules.push("." + uid + " .r" + i + " { }");
-      }
-
-      if ($style[0].styleSheet) { // IE
-        $style[0].styleSheet.cssText = rules.join(" ");
-      } else {
-        $style[0].appendChild(document.createTextNode(rules.join(" ")));
-      }
-
-      stylesheet = $style[0].sheet || $style[0].styleSheet; // IE8 -> styleSheet
-
-      // cache column CSS rules
-      columnCssRulesL = [];
-      columnCssRulesR = [];
-      var cssRules = (stylesheet.cssRules || stylesheet.rules);
-      var matches, columnIdx;
-      for (var i = 0; i < cssRules.length; i++) {
-        var selector = cssRules[i].selectorText;
-        if (matches = /\.l\d+/.exec(selector)) {
-          columnIdx = parseInt(matches[0].substr(2, matches[0].length - 2), 10);
-          columnCssRulesL[columnIdx] = cssRules[i];
-        } else if (matches = /\.r\d+/.exec(selector)) {
-          columnIdx = parseInt(matches[0].substr(2, matches[0].length - 2), 10);
-          columnCssRulesR[columnIdx] = cssRules[i];
-        }
-      }
-    }
-
-    function getColumnCssRules(idx) {
-      if (!stylesheet) {
-        createCssRules()
-      };
-
-      return {
-        "left": columnCssRulesL[idx],
-        "right": columnCssRulesR[idx]
-      };
-    }
-
-    function removeCssRules() {
-      $style.remove();
-      stylesheet = null;
-    }
-
-    function destroy() {
-      getEditorLock().cancelCurrentEdit();
-
-      trigger(self.onBeforeDestroy, {});
-
-      var i = plugins.length;
-      while(i--) {
-        unregisterPlugin(plugins[i]);
-      }
-
-      if (options.enableColumnReorder) {
-          $headers.filter(":ui-sortable").sortable("destroy");
-      }
-
-      unbindAncestorScrollEvents();
-      $container.unbind(".slickgrid");
-      removeCssRules();
-
-      $canvas.unbind("draginit dragstart dragend drag");
-      $container.empty().removeClass(uid);
-    }
-
-
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    // General
-
-    function trigger(evt, args, e) {
-      e = e || new Slick.EventData();
-      args = args || {};
-      args.grid = self;
-      return evt.notify(args, e, self);
-    }
-
-    function getEditorLock() {
-      return options.editorLock;
-    }
-
-    function getEditController() {
-      return editController;
-    }
-
-    function getColumnIndex(id) {
-      return columnsById[id];
-    }
-
-    function autosizeColumns() {
-      var i, c,
-          widths = [],
-          shrinkLeeway = 0,
-          total = 0,
-          prevTotal,
-          availWidth = viewportHasVScroll ? viewportW - scrollbarDimensions.width : viewportW;
-
-      for (i = 0; i < columns.length; i++) {
-        c = columns[i];
-        widths.push(c.width);
-        total += c.width;
-        if (c.resizable) {
-          shrinkLeeway += c.width - Math.max(c.minWidth, absoluteColumnMinWidth);
-        }
-      }
-
-      // shrink
-      prevTotal = total;
-      while (total > availWidth && shrinkLeeway) {
-        var shrinkProportion = (total - availWidth) / shrinkLeeway;
-        for (i = 0; i < columns.length && total > availWidth; i++) {
-          c = columns[i];
-          var width = widths[i];
-          if (!c.resizable || width <= c.minWidth || width <= absoluteColumnMinWidth) {
-            continue;
-          }
-          var absMinWidth = Math.max(c.minWidth, absoluteColumnMinWidth);
-          var shrinkSize = Math.floor(shrinkProportion * (width - absMinWidth)) || 1;
-          shrinkSize = Math.min(shrinkSize, width - absMinWidth);
-          total -= shrinkSize;
-          shrinkLeeway -= shrinkSize;
-          widths[i] -= shrinkSize;
-        }
-        if (prevTotal <= total) {  // avoid infinite loop
-          break;
-        }
-        prevTotal = total;
-      }
-
-      // grow
-      prevTotal = total;
-      while (total < availWidth) {
-        var growProportion = availWidth / total;
-        for (i = 0; i < columns.length && total < availWidth; i++) {
-          c = columns[i];
-          var currentWidth = widths[i];
-          var growSize;
-
-          if (!c.resizable || c.maxWidth <= currentWidth) {
-            growSize = 0;
-          } else {
-            growSize = Math.min(Math.floor(growProportion * currentWidth) - currentWidth, (c.maxWidth - currentWidth) || 1000000) || 1;
-          }
-          total += growSize;
-          widths[i] += growSize;
-        }
-        if (prevTotal >= total) {  // avoid infinite loop
-          break;
-        }
-        prevTotal = total;
-      }
-
-      var reRender = false;
-      for (i = 0; i < columns.length; i++) {
-        if (columns[i].rerenderOnResize && columns[i].width != widths[i]) {
-          reRender = true;
-        }
-        columns[i].width = widths[i];
-      }
-
-      applyColumnHeaderWidths();
-      updateCanvasWidth(true);
-      if (reRender) {
-        invalidateAllRows();
-        render();
-      }
-    }
-
-    function applyColumnHeaderWidths() {
-      if (!initialized) { return; }
-      var h;
-      for (var i = 0, headers = $headers.children(), ii = headers.length; i < ii; i++) {
-        h = $(headers[i]);
-        if (h.width() !== columns[i].width - headerColumnWidthDiff) {
-          h.width(columns[i].width - headerColumnWidthDiff);
-        }
-      }
-
-      updateColumnCaches();
-    }
-
-    function applyColumnWidths() {
-      var x = 0, w, rule;
-      for (var i = 0; i < columns.length; i++) {
-        w = columns[i].width;
-
-        rule = getColumnCssRules(i);
-        rule.left.style.left = x + "px";
-        rule.right.style.right = (canvasWidth - x - w) + "px";
-
-        x += columns[i].width;
-      }
-    }
-
-    function setSortColumn(columnId, ascending) {
-      setSortColumns([{ columnId: columnId, sortAsc: ascending}]);
-    }
-
-    function setSortColumns(cols) {
-      sortColumns = cols;
-
-      var headerColumnEls = $headers.children();
-      headerColumnEls
-          .removeClass("slick-header-column-sorted")
-          .find(".slick-sort-indicator")
-              .removeClass("slick-sort-indicator-asc slick-sort-indicator-desc");
-
-      $.each(sortColumns, function(i, col) {
-        if (col.sortAsc == null) {
-          col.sortAsc = true;
-        }
-        var columnIndex = getColumnIndex(col.columnId);
-        if (columnIndex != null) {
-          headerColumnEls.eq(columnIndex)
-              .addClass("slick-header-column-sorted")
-              .find(".slick-sort-indicator")
-                  .addClass(col.sortAsc ? "slick-sort-indicator-asc" : "slick-sort-indicator-desc");
-        }
-      });
-    }
-
-    function getSortColumns() {
-      return sortColumns;
-    }
-
-    function handleSelectedRangesChanged(e, ranges) {
-      selectedRows = [];
-      var hash = {};
-      for (var i = 0; i < ranges.length; i++) {
-        for (var j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
-          if (!hash[j]) {  // prevent duplicates
-            selectedRows.push(j);
-            hash[j] = {};
-          }
-          for (var k = ranges[i].fromCell; k <= ranges[i].toCell; k++) {
-            if (canCellBeSelected(j, k)) {
-              hash[j][columns[k].id] = options.selectedCellCssClass;
             }
-          }
+            applyColumnHeaderWidths();
+            if (options.syncColumnCellResize) {
+              applyColumnWidths();
+            }
+          })
+          .bind("dragend", function (e, dd) {
+            var newWidth;
+            $(this).parent().removeClass("slick-header-column-active");
+            for (j = 0; j < columnElements.length; j++) {
+              c = columns[j];
+              newWidth = $(columnElements[j]).outerWidth();
+
+              if (c.previousWidth !== newWidth && c.rerenderOnResize) {
+                invalidateAllRows();
+              }
+            }
+            updateCanvasWidth(true);
+            render();
+            trigger(self.onColumnsResized, {});
+          });
+    });
+  }
+
+  function getVBoxDelta($el) {
+    var p = ["borderTopWidth", "borderBottomWidth", "paddingTop", "paddingBottom"];
+    var delta = 0;
+    $.each(p, function (n, val) {
+      delta += parseFloat($el.css(val)) || 0;
+    });
+    return delta;
+  }
+
+  function measureCellPaddingAndBorder() {
+    var el;
+    var h = ["borderLeftWidth", "borderRightWidth", "paddingLeft", "paddingRight"];
+    var v = ["borderTopWidth", "borderBottomWidth", "paddingTop", "paddingBottom"];
+
+    el = $("<div class='ui-state-default slick-header-column' style='visibility:hidden'>-</div>").appendTo($headers);
+    headerColumnWidthDiff = headerColumnHeightDiff = 0;
+    if (el.css("box-sizing") != "border-box" && el.css("-moz-box-sizing") != "border-box" && el.css("-webkit-box-sizing") != "border-box") {
+      $.each(h, function (n, val) {
+        headerColumnWidthDiff += parseFloat(el.css(val)) || 0;
+      });
+      $.each(v, function (n, val) {
+        headerColumnHeightDiff += parseFloat(el.css(val)) || 0;
+      });
+    }
+    el.remove();
+
+    var r = $("<div class='slick-row' />").appendTo($canvas);
+    el = $("<div class='slick-cell' id='' style='visibility:hidden'>-</div>").appendTo(r);
+    cellWidthDiff = cellHeightDiff = 0;
+    if (el.css("box-sizing") != "border-box" && el.css("-moz-box-sizing") != "border-box" && el.css("-webkit-box-sizing") != "border-box") {
+      $.each(h, function (n, val) {
+        cellWidthDiff += parseFloat(el.css(val)) || 0;
+      });
+      $.each(v, function (n, val) {
+        cellHeightDiff += parseFloat(el.css(val)) || 0;
+      });
+    }
+    r.remove();
+
+    absoluteColumnMinWidth = Math.max(headerColumnWidthDiff, cellWidthDiff);
+  }
+
+  function createCssRules() {
+    $style = $("<style type='text/css' rel='stylesheet' />").appendTo($("head"));
+    var rowHeight = (options.rowHeight - cellHeightDiff);
+    var rules = [
+      "." + uid + " .slick-header-column { left: 1000px; }",
+      "." + uid + " .slick-top-panel { height:" + options.topPanelHeight + "px; }",
+      "." + uid + " .slick-headerrow-columns { height:" + options.headerRowHeight + "px; }",
+      "." + uid + " .slick-cell { height:" + rowHeight + "px; }",
+      "." + uid + " .slick-row { height:" + options.rowHeight + "px; }"
+    ];
+
+    for (var i = 0; i < columns.length; i++) {
+      rules.push("." + uid + " .l" + i + " { }");
+      rules.push("." + uid + " .r" + i + " { }");
+    }
+
+    if ($style[0].styleSheet) { // IE
+      $style[0].styleSheet.cssText = rules.join(" ");
+    } else {
+      $style[0].appendChild(document.createTextNode(rules.join(" ")));
+    }
+
+    stylesheet = $style[0].sheet || $style[0].styleSheet; // IE8 -> styleSheet
+
+    // cache column CSS rules
+    columnCssRulesL = [];
+    columnCssRulesR = [];
+    var cssRules = (stylesheet.cssRules || stylesheet.rules);
+    var matches, columnIdx;
+    for (var i = 0; i < cssRules.length; i++) {
+      var selector = cssRules[i].selectorText;
+      if (matches = /\.l\d+/.exec(selector)) {
+        columnIdx = parseInt(matches[0].substr(2, matches[0].length - 2), 10);
+        columnCssRulesL[columnIdx] = cssRules[i];
+      } else if (matches = /\.r\d+/.exec(selector)) {
+        columnIdx = parseInt(matches[0].substr(2, matches[0].length - 2), 10);
+        columnCssRulesR[columnIdx] = cssRules[i];
+      }
+    }
+  }
+
+  function getColumnCssRules(idx) {
+    if (!stylesheet) {
+      createCssRules()
+    };
+
+    return {
+      "left": columnCssRulesL[idx],
+      "right": columnCssRulesR[idx]
+    };
+  }
+
+  function removeCssRules() {
+    $style.remove();
+    stylesheet = null;
+  }
+
+  function destroy() {
+    getEditorLock().cancelCurrentEdit();
+
+    trigger(self.onBeforeDestroy, {});
+
+    var i = plugins.length;
+    while(i--) {
+      unregisterPlugin(plugins[i]);
+    }
+
+    if (options.enableColumnReorder) {
+        $headers.filter(":ui-sortable").sortable("destroy");
+    }
+
+    unbindAncestorScrollEvents();
+    $container.unbind(".slickgrid");
+    removeCssRules();
+
+    $canvas.unbind("draginit dragstart dragend drag");
+    $container.empty().removeClass(uid);
+  }
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // General
+
+  function trigger(evt, args, e) {
+    e = e || new Slick.EventData();
+    args = args || {};
+    args.grid = self;
+    return evt.notify(args, e, self);
+  }
+
+  function getEditorLock() {
+    return options.editorLock;
+  }
+
+  function getEditController() {
+    return editController;
+  }
+
+  function getColumnIndex(id) {
+    return columnsById[id];
+  }
+
+  function autosizeColumns() {
+    var i, c,
+        widths = [],
+        shrinkLeeway = 0,
+        total = 0,
+        prevTotal,
+        availWidth = viewportHasVScroll ? viewportW - scrollbarDimensions.width : viewportW;
+
+    for (i = 0; i < columns.length; i++) {
+      c = columns[i];
+      widths.push(c.width);
+      total += c.width;
+      if (c.resizable) {
+        shrinkLeeway += c.width - Math.max(c.minWidth, absoluteColumnMinWidth);
+      }
+    }
+
+    // shrink
+    prevTotal = total;
+    while (total > availWidth && shrinkLeeway) {
+      var shrinkProportion = (total - availWidth) / shrinkLeeway;
+      for (i = 0; i < columns.length && total > availWidth; i++) {
+        c = columns[i];
+        var width = widths[i];
+        if (!c.resizable || width <= c.minWidth || width <= absoluteColumnMinWidth) {
+          continue;
         }
+        var absMinWidth = Math.max(c.minWidth, absoluteColumnMinWidth);
+        var shrinkSize = Math.floor(shrinkProportion * (width - absMinWidth)) || 1;
+        shrinkSize = Math.min(shrinkSize, width - absMinWidth);
+        total -= shrinkSize;
+        shrinkLeeway -= shrinkSize;
+        widths[i] -= shrinkSize;
       }
-
-      setCellCssStyles(options.selectedCellCssClass, hash);
-
-      trigger(self.onSelectedRowsChanged, {rows: getSelectedRows()}, e);
-    }
-
-    function getColumns() {
-      return columns;
-    }
-
-    function updateColumnCaches() {
-      // Pre-calculate cell boundaries.
-      columnPosLeft = [];
-      columnPosRight = [];
-      var x = 0;
-      for (var i = 0, ii = columns.length; i < ii; i++) {
-        columnPosLeft[i] = x;
-        columnPosRight[i] = x + columns[i].width;
-        x += columns[i].width;
+      if (prevTotal <= total) {  // avoid infinite loop
+        break;
       }
+      prevTotal = total;
     }
 
-    function setColumns(columnDefinitions) {
-      columns = columnDefinitions;
+    // grow
+    prevTotal = total;
+    while (total < availWidth) {
+      var growProportion = availWidth / total;
+      for (i = 0; i < columns.length && total < availWidth; i++) {
+        c = columns[i];
+        var currentWidth = widths[i];
+        var growSize;
 
-      columnsById = {};
-      for (var i = 0; i < columns.length; i++) {
-        var m = columns[i] = $.extend({}, columnDefaults, columns[i]);
-        columnsById[m.id] = i;
-        if (m.minWidth && m.width < m.minWidth) {
-          m.width = m.minWidth;
+        if (!c.resizable || c.maxWidth <= currentWidth) {
+          growSize = 0;
+        } else {
+          growSize = Math.min(Math.floor(growProportion * currentWidth) - currentWidth, (c.maxWidth - currentWidth) || 1000000) || 1;
         }
-        if (m.maxWidth && m.width > m.maxWidth) {
-          m.width = m.maxWidth;
-        }
+        total += growSize;
+        widths[i] += growSize;
       }
-
-      updateColumnCaches();
-
-      if (initialized) {
-        invalidateAllRows();
-        createColumnHeaders();
-        removeCssRules();
-        createCssRules();
-        resizeCanvas();
-        applyColumnWidths();
-        handleScroll();
+      if (prevTotal >= total) {  // avoid infinite loop
+        break;
       }
+      prevTotal = total;
     }
 
-    function getOptions() {
-      return options;
+    var reRender = false;
+    for (i = 0; i < columns.length; i++) {
+      if (columns[i].rerenderOnResize && columns[i].width != widths[i]) {
+        reRender = true;
+      }
+      columns[i].width = widths[i];
     }
 
-    function setOptions(args) {
-      if (!getEditorLock().commitCurrentEdit()) {
-        return;
-      }
-
-      makeActiveCellNormal();
-
-      if (options.enableAddRow !== args.enableAddRow) {
-        invalidateRow(getDataLength());
-      }
-
-      options = $.extend(options, args);
-      validateAndEnforceOptions();
-
-      $viewport.css("overflow-y", options.autoHeight ? "hidden" : "auto");
+    applyColumnHeaderWidths();
+    updateCanvasWidth(true);
+    if (reRender) {
+      invalidateAllRows();
       render();
     }
+  }
 
-    function validateAndEnforceOptions() {
-      if (options.autoHeight) {
-        options.leaveSpaceForNewRows = false;
+  function applyColumnHeaderWidths() {
+    if (!initialized) { return; }
+    var h;
+    for (var i = 0, headers = $headers.children(), ii = headers.length; i < ii; i++) {
+      h = $(headers[i]);
+      if (h.width() !== columns[i].width - headerColumnWidthDiff) {
+        h.width(columns[i].width - headerColumnWidthDiff);
       }
     }
 
-    function setData(newData, scrollToTop) {
-      data = newData;
+    updateColumnCaches();
+  }
+
+  function applyColumnWidths() {
+    var x = 0, w, rule;
+    for (var i = 0; i < columns.length; i++) {
+      w = columns[i].width;
+
+      rule = getColumnCssRules(i);
+      rule.left.style.left = x + "px";
+      rule.right.style.right = (canvasWidth - x - w) + "px";
+
+      x += columns[i].width;
+    }
+  }
+
+  function setSortColumn(columnId, ascending) {
+    setSortColumns([{ columnId: columnId, sortAsc: ascending}]);
+  }
+
+  function setSortColumns(cols) {
+    sortColumns = cols;
+
+    var headerColumnEls = $headers.children();
+    headerColumnEls
+        .removeClass("slick-header-column-sorted")
+        .find(".slick-sort-indicator")
+            .removeClass("slick-sort-indicator-asc slick-sort-indicator-desc");
+
+    $.each(sortColumns, function(i, col) {
+      if (col.sortAsc == null) {
+        col.sortAsc = true;
+      }
+      var columnIndex = getColumnIndex(col.columnId);
+      if (columnIndex != null) {
+        headerColumnEls.eq(columnIndex)
+            .addClass("slick-header-column-sorted")
+            .find(".slick-sort-indicator")
+                .addClass(col.sortAsc ? "slick-sort-indicator-asc" : "slick-sort-indicator-desc");
+      }
+    });
+  }
+
+  function getSortColumns() {
+    return sortColumns;
+  }
+
+  function handleSelectedRangesChanged(e, ranges) {
+    selectedRows = [];
+    var hash = {};
+    for (var i = 0; i < ranges.length; i++) {
+      for (var j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
+        if (!hash[j]) {  // prevent duplicates
+          selectedRows.push(j);
+          hash[j] = {};
+        }
+        for (var k = ranges[i].fromCell; k <= ranges[i].toCell; k++) {
+          if (canCellBeSelected(j, k)) {
+            hash[j][columns[k].id] = options.selectedCellCssClass;
+          }
+        }
+      }
+    }
+
+    setCellCssStyles(options.selectedCellCssClass, hash);
+
+    trigger(self.onSelectedRowsChanged, {rows: getSelectedRows()}, e);
+  }
+
+  function getColumns() {
+    return columns;
+  }
+
+  function updateColumnCaches() {
+    // Pre-calculate cell boundaries.
+    columnPosLeft = [];
+    columnPosRight = [];
+    var x = 0;
+    for (var i = 0, ii = columns.length; i < ii; i++) {
+      columnPosLeft[i] = x;
+      columnPosRight[i] = x + columns[i].width;
+      x += columns[i].width;
+    }
+  }
+
+  function setColumns(columnDefinitions) {
+    columns = columnDefinitions;
+
+    columnsById = {};
+    for (var i = 0; i < columns.length; i++) {
+      var m = columns[i] = $.extend({}, columnDefaults, columns[i]);
+      columnsById[m.id] = i;
+      if (m.minWidth && m.width < m.minWidth) {
+        m.width = m.minWidth;
+      }
+      if (m.maxWidth && m.width > m.maxWidth) {
+        m.width = m.maxWidth;
+      }
+    }
+
+    updateColumnCaches();
+
+    if (initialized) {
       invalidateAllRows();
-      updateRowCount();
-      if (scrollToTop) {
-        scrollTo(0);
-      }
+      createColumnHeaders();
+      removeCssRules();
+      createCssRules();
+      resizeCanvas();
+      applyColumnWidths();
+      handleScroll();
+    }
+  }
+
+  function getOptions() {
+    return options;
+  }
+
+  function setOptions(args) {
+    if (!getEditorLock().commitCurrentEdit()) {
+      return;
     }
 
-    function getData() {
-      return data;
+    makeActiveCellNormal();
+
+    if (options.enableAddRow !== args.enableAddRow) {
+      invalidateRow(getDataLength());
     }
 
-    function getDataLength() {
-      if (data.getLength) {
-        return data.getLength();
+    options = $.extend(options, args);
+    validateAndEnforceOptions();
+
+    $viewport.css("overflow-y", options.autoHeight ? "hidden" : "auto");
+    render();
+  }
+
+  function validateAndEnforceOptions() {
+    if (options.autoHeight) {
+      options.leaveSpaceForNewRows = false;
+    }
+  }
+
+  function setData(newData, scrollToTop) {
+    data = newData;
+    invalidateAllRows();
+    updateRowCount();
+    if (scrollToTop) {
+      scrollTo(0);
+    }
+  }
+
+  function getData() {
+    return data;
+  }
+
+  function getDataLength() {
+    if (data.getLength) {
+      return data.getLength();
+    } else {
+      return data.length;
+    }
+  }
+
+  function getDataLengthIncludingAddNew() {
+    return getDataLength() + (options.enableAddRow ? 1 : 0);
+  }
+
+  function getDataItem(i) {
+    if (data.getItem) {
+      return data.getItem(i);
+    } else {
+      return data[i];
+    }
+  }
+
+  function getTopPanel() {
+    return $topPanel[0];
+  }
+
+  function setTopPanelVisibility(visible) {
+    if (options.showTopPanel != visible) {
+      options.showTopPanel = visible;
+      if (visible) {
+        $topPanelScroller.slideDown("fast", resizeCanvas);
       } else {
-        return data.length;
+        $topPanelScroller.slideUp("fast", resizeCanvas);
       }
     }
+  }
 
-    function getDataLengthIncludingAddNew() {
-      return getDataLength() + (options.enableAddRow ? 1 : 0);
-    }
-
-    function getDataItem(i) {
-      if (data.getItem) {
-        return data.getItem(i);
+  function setHeaderRowVisibility(visible) {
+    if (options.showHeaderRow != visible) {
+      options.showHeaderRow = visible;
+      if (visible) {
+        $headerRowScroller.slideDown("fast", resizeCanvas);
       } else {
-        return data[i];
+        $headerRowScroller.slideUp("fast", resizeCanvas);
+      }
+    }
+  }
+
+  function getContainerNode() {
+    return $container.get(0);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // Rendering / Scrolling
+
+  function getRowTop(row) {
+    return options.rowHeight * row - offset;
+  }
+
+  function getRowFromPosition(y) {
+    return Math.floor((y + offset) / options.rowHeight);
+  }
+
+  function scrollTo(y) {
+    y = Math.max(y, 0);
+    y = Math.min(y, th - viewportH + (viewportHasHScroll ? scrollbarDimensions.height : 0));
+
+    var oldOffset = offset;
+
+    page = Math.min(n - 1, Math.floor(y / ph));
+    offset = Math.round(page * cj);
+    var newScrollTop = y - offset;
+
+    if (offset != oldOffset) {
+      var range = getVisibleRange(newScrollTop);
+      cleanupRows(range);
+      updateRowPositions();
+    }
+
+    if (prevScrollTop != newScrollTop) {
+      vScrollDir = (prevScrollTop + oldOffset < newScrollTop + offset) ? 1 : -1;
+      $viewport[0].scrollTop = (lastRenderedScrollTop = scrollTop = prevScrollTop = newScrollTop);
+
+      trigger(self.onViewportChanged, {});
+    }
+  }
+
+  function defaultFormatter(row, cell, value, columnDef, dataContext) {
+    if (value == null) {
+      return "";
+    } else {
+      return (value + "").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+    }
+  }
+
+  function getFormatter(row, column) {
+    var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
+
+    // look up by id, then index
+    var columnOverrides = rowMetadata &&
+        rowMetadata.columns &&
+        (rowMetadata.columns[column.id] || rowMetadata.columns[getColumnIndex(column.id)]);
+
+    return (columnOverrides && columnOverrides.formatter) ||
+        (rowMetadata && rowMetadata.formatter) ||
+        column.formatter ||
+        (options.formatterFactory && options.formatterFactory.getFormatter(column)) ||
+        options.defaultFormatter;
+  }
+
+  function getEditor(row, cell) {
+    var column = columns[cell];
+    var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
+    var columnMetadata = rowMetadata && rowMetadata.columns;
+
+    if (columnMetadata && columnMetadata[column.id] && columnMetadata[column.id].editor !== undefined) {
+      return columnMetadata[column.id].editor;
+    }
+    if (columnMetadata && columnMetadata[cell] && columnMetadata[cell].editor !== undefined) {
+      return columnMetadata[cell].editor;
+    }
+
+    return column.editor || (options.editorFactory && options.editorFactory.getEditor(column));
+  }
+
+  function getDataItemValueForColumn(item, columnDef) {
+    if (options.dataItemColumnValueExtractor) {
+      return options.dataItemColumnValueExtractor(item, columnDef);
+    }
+    return item[columnDef.field];
+  }
+
+  function appendRowHtml(stringArray, row, range, dataLength) {
+    var d = getDataItem(row);
+    var dataLoading = row < dataLength && !d;
+    var rowCss = "slick-row" +
+        (dataLoading ? " loading" : "") +
+        (row === activeRow ? " active" : "") +
+        (row % 2 == 1 ? " odd" : " even");
+
+    if (!d) {
+      rowCss += " " + options.addNewRowCssClass;
+    }
+
+    var metadata = data.getItemMetadata && data.getItemMetadata(row);
+
+    if (metadata && metadata.cssClasses) {
+      rowCss += " " + metadata.cssClasses;
+    }
+
+    stringArray.push("<div class='ui-widget-content " + rowCss + "' style='top:" + getRowTop(row) + "px'>");
+
+    var colspan, m;
+    for (var i = 0, ii = columns.length; i < ii; i++) {
+      m = columns[i];
+      colspan = 1;
+      if (metadata && metadata.columns) {
+        var columnData = metadata.columns[m.id] || metadata.columns[i];
+        colspan = (columnData && columnData.colspan) || 1;
+        if (colspan === "*") {
+          colspan = ii - i;
+        }
+      }
+
+      // Do not render cells outside of the viewport.
+      if (columnPosRight[Math.min(ii - 1, i + colspan - 1)] > range.leftPx) {
+        if (columnPosLeft[i] > range.rightPx) {
+          // All columns to the right are outside the range.
+          break;
+        }
+
+        appendCellHtml(stringArray, row, i, colspan, d);
+      }
+
+      if (colspan > 1) {
+        i += (colspan - 1);
       }
     }
 
-    function getTopPanel() {
-      return $topPanel[0];
+    stringArray.push("</div>");
+  }
+
+  function appendCellHtml(stringArray, row, cell, colspan, item) {
+    var m = columns[cell];
+    var cellCss = "slick-cell l" + cell + " r" + Math.min(columns.length - 1, cell + colspan - 1) +
+        (m.cssClass ? " " + m.cssClass : "");
+    if (row === activeRow && cell === activeCell) {
+      cellCss += (" active");
     }
 
-    function setTopPanelVisibility(visible) {
-      if (options.showTopPanel != visible) {
-        options.showTopPanel = visible;
-        if (visible) {
-          $topPanelScroller.slideDown("fast", resizeCanvas);
-        } else {
-          $topPanelScroller.slideUp("fast", resizeCanvas);
+    // TODO:  merge them together in the setter
+    for (var key in cellCssClasses) {
+      if (cellCssClasses[key][row] && cellCssClasses[key][row][m.id]) {
+        cellCss += (" " + cellCssClasses[key][row][m.id]);
+      }
+    }
+
+    stringArray.push("<div class='" + cellCss + "'>");
+
+    // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
+    if (item) {
+      var value = getDataItemValueForColumn(item, m);
+      stringArray.push(getFormatter(row, m)(row, cell, value, m, item));
+    }
+
+    stringArray.push("</div>");
+
+    rowsCache[row].cellRenderQueue.push(cell);
+    rowsCache[row].cellColSpans[cell] = colspan;
+  }
+
+
+  function cleanupRows(rangeToKeep) {
+    for (var i in rowsCache) {
+      if (((i = parseInt(i, 10)) !== activeRow) && (i < rangeToKeep.top || i > rangeToKeep.bottom)) {
+        removeRowFromCache(i);
+      }
+    }
+  }
+
+  function invalidate() {
+    updateRowCount();
+    invalidateAllRows();
+    render();
+  }
+
+  function invalidateAllRows() {
+    if (currentEditor) {
+      makeActiveCellNormal();
+    }
+    for (var row in rowsCache) {
+      removeRowFromCache(row);
+    }
+  }
+
+  function removeRowFromCache(row) {
+    var cacheEntry = rowsCache[row];
+    if (!cacheEntry) {
+      return;
+    }
+
+    if (rowNodeFromLastMouseWheelEvent == cacheEntry.rowNode) {
+      cacheEntry.rowNode.style.display = 'none';
+      zombieRowNodeFromLastMouseWheelEvent = rowNodeFromLastMouseWheelEvent;
+    } else {
+      $canvas[0].removeChild(cacheEntry.rowNode);
+    }
+
+    delete rowsCache[row];
+    delete postProcessedRows[row];
+    renderedRows--;
+    counter_rows_removed++;
+  }
+
+  function invalidateRows(rows) {
+    var i, rl;
+    if (!rows || !rows.length) {
+      return;
+    }
+    vScrollDir = 0;
+    for (i = 0, rl = rows.length; i < rl; i++) {
+      if (currentEditor && activeRow === rows[i]) {
+        makeActiveCellNormal();
+      }
+      if (rowsCache[rows[i]]) {
+        removeRowFromCache(rows[i]);
+      }
+    }
+  }
+
+  function invalidateRow(row) {
+    invalidateRows([row]);
+  }
+
+  function updateCell(row, cell) {
+    var cellNode = getCellNode(row, cell);
+    if (!cellNode) {
+      return;
+    }
+
+    var m = columns[cell], d = getDataItem(row);
+    if (currentEditor && activeRow === row && activeCell === cell) {
+      currentEditor.loadValue(d);
+    } else {
+      cellNode.innerHTML = d ? getFormatter(row, m)(row, cell, getDataItemValueForColumn(d, m), m, d) : "";
+      invalidatePostProcessingResults(row);
+    }
+  }
+
+  function updateRow(row) {
+    var cacheEntry = rowsCache[row];
+    if (!cacheEntry) {
+      return;
+    }
+
+    ensureCellNodesInRowsCache(row);
+
+    var d = getDataItem(row);
+
+    for (var columnIdx in cacheEntry.cellNodesByColumnIdx) {
+      if (!cacheEntry.cellNodesByColumnIdx.hasOwnProperty(columnIdx)) {
+        continue;
+      }
+
+      columnIdx = columnIdx | 0;
+      var m = columns[columnIdx],
+          node = cacheEntry.cellNodesByColumnIdx[columnIdx];
+
+      if (row === activeRow && columnIdx === activeCell && currentEditor) {
+        currentEditor.loadValue(d);
+      } else if (d) {
+        node.innerHTML = getFormatter(row, m)(row, columnIdx, getDataItemValueForColumn(d, m), m, d);
+      } else {
+        node.innerHTML = "";
+      }
+    }
+
+    invalidatePostProcessingResults(row);
+  }
+
+  function getViewportHeight() {
+    return parseFloat($.css($container[0], "height", true)) -
+        parseFloat($.css($container[0], "paddingTop", true)) -
+        parseFloat($.css($container[0], "paddingBottom", true)) -
+        parseFloat($.css($headerScroller[0], "height")) - getVBoxDelta($headerScroller) -
+        (options.showTopPanel ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0) -
+        (options.showHeaderRow ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0);
+  }
+
+  function resizeCanvas() {
+    if (!initialized) { return; }
+    if (options.autoHeight) {
+      viewportH = options.rowHeight * getDataLengthIncludingAddNew();
+    } else {
+      viewportH = getViewportHeight();
+    }
+
+    numVisibleRows = Math.ceil(viewportH / options.rowHeight);
+    viewportW = parseFloat($.css($container[0], "width", true));
+    if (!options.autoHeight) {
+      $viewport.height(viewportH);
+    }
+
+    if (options.forceFitColumns) {
+      autosizeColumns();
+    }
+
+    updateRowCount();
+    handleScroll();
+    // Since the width has changed, force the render() to reevaluate virtually rendered cells.
+    lastRenderedScrollLeft = -1;
+    render();
+  }
+
+  function updateRowCount() {
+    if (!initialized) { return; }
+
+    var dataLengthIncludingAddNew = getDataLengthIncludingAddNew();
+    var numberOfRows = dataLengthIncludingAddNew +
+        (options.leaveSpaceForNewRows ? numVisibleRows - 1 : 0);
+
+    var oldViewportHasVScroll = viewportHasVScroll;
+    // with autoHeight, we do not need to accommodate the vertical scroll bar
+    viewportHasVScroll = !options.autoHeight && (numberOfRows * options.rowHeight > viewportH);
+
+    makeActiveCellNormal();
+
+    // remove the rows that are now outside of the data range
+    // this helps avoid redundant calls to .removeRow() when the size of the data decreased by thousands of rows
+    var l = dataLengthIncludingAddNew - 1;
+    for (var i in rowsCache) {
+      if (i >= l) {
+        removeRowFromCache(i);
+      }
+    }
+
+    if (activeCellNode && activeRow > l) {
+      resetActiveCell();
+    }
+
+    var oldH = h;
+    th = Math.max(options.rowHeight * numberOfRows, viewportH - scrollbarDimensions.height);
+    if (th < maxSupportedCssHeight) {
+      // just one page
+      h = ph = th;
+      n = 1;
+      cj = 0;
+    } else {
+      // break into pages
+      h = maxSupportedCssHeight;
+      ph = h / 100;
+      n = Math.floor(th / ph);
+      cj = (th - h) / (n - 1);
+    }
+
+    if (h !== oldH) {
+      $canvas.css("height", h);
+      scrollTop = $viewport[0].scrollTop;
+    }
+
+    var oldScrollTopInRange = (scrollTop + offset <= th - viewportH);
+
+    if (th == 0 || scrollTop == 0) {
+      page = offset = 0;
+    } else if (oldScrollTopInRange) {
+      // maintain virtual position
+      scrollTo(scrollTop + offset);
+    } else {
+      // scroll to bottom
+      scrollTo(th - viewportH);
+    }
+
+    if (h != oldH && options.autoHeight) {
+      resizeCanvas();
+    }
+
+    if (options.forceFitColumns && oldViewportHasVScroll != viewportHasVScroll) {
+      autosizeColumns();
+    }
+    updateCanvasWidth(false);
+  }
+
+  function getVisibleRange(viewportTop, viewportLeft) {
+    if (viewportTop == null) {
+      viewportTop = scrollTop;
+    }
+    if (viewportLeft == null) {
+      viewportLeft = scrollLeft;
+    }
+
+    return {
+      top: getRowFromPosition(viewportTop),
+      bottom: getRowFromPosition(viewportTop + viewportH) + 1,
+      leftPx: viewportLeft,
+      rightPx: viewportLeft + viewportW
+    };
+  }
+
+  function getRenderedRange(viewportTop, viewportLeft) {
+    var range = getVisibleRange(viewportTop, viewportLeft);
+    var buffer = Math.round(viewportH / options.rowHeight);
+    var minBuffer = 3;
+
+    if (vScrollDir == -1) {
+      range.top -= buffer;
+      range.bottom += minBuffer;
+    } else if (vScrollDir == 1) {
+      range.top -= minBuffer;
+      range.bottom += buffer;
+    } else {
+      range.top -= minBuffer;
+      range.bottom += minBuffer;
+    }
+
+    range.top = Math.max(0, range.top);
+    range.bottom = Math.min(getDataLengthIncludingAddNew() - 1, range.bottom);
+
+    range.leftPx -= viewportW;
+    range.rightPx += viewportW;
+
+    range.leftPx = Math.max(0, range.leftPx);
+    range.rightPx = Math.min(canvasWidth, range.rightPx);
+
+    return range;
+  }
+
+  function ensureCellNodesInRowsCache(row) {
+    var cacheEntry = rowsCache[row];
+    if (cacheEntry) {
+      if (cacheEntry.cellRenderQueue.length) {
+        var lastChild = cacheEntry.rowNode.lastChild;
+        while (cacheEntry.cellRenderQueue.length) {
+          var columnIdx = cacheEntry.cellRenderQueue.pop();
+          cacheEntry.cellNodesByColumnIdx[columnIdx] = lastChild;
+          lastChild = lastChild.previousSibling;
+        }
+      }
+    }
+  }
+
+  function cleanUpCells(range, row) {
+    var totalCellsRemoved = 0;
+    var cacheEntry = rowsCache[row];
+
+    // Remove cells outside the range.
+    var cellsToRemove = [];
+    for (var i in cacheEntry.cellNodesByColumnIdx) {
+      // I really hate it when people mess with Array.prototype.
+      if (!cacheEntry.cellNodesByColumnIdx.hasOwnProperty(i)) {
+        continue;
+      }
+
+      // This is a string, so it needs to be cast back to a number.
+      i = i | 0;
+
+      var colspan = cacheEntry.cellColSpans[i];
+      if (columnPosLeft[i] > range.rightPx ||
+        columnPosRight[Math.min(columns.length - 1, i + colspan - 1)] < range.leftPx) {
+        if (!(row == activeRow && i == activeCell)) {
+          cellsToRemove.push(i);
         }
       }
     }
 
-    function setHeaderRowVisibility(visible) {
-      if (options.showHeaderRow != visible) {
-        options.showHeaderRow = visible;
-        if (visible) {
-          $headerRowScroller.slideDown("fast", resizeCanvas);
-        } else {
-          $headerRowScroller.slideUp("fast", resizeCanvas);
-        }
+    var cellToRemove;
+    while ((cellToRemove = cellsToRemove.pop()) != null) {
+      cacheEntry.rowNode.removeChild(cacheEntry.cellNodesByColumnIdx[cellToRemove]);
+      delete cacheEntry.cellColSpans[cellToRemove];
+      delete cacheEntry.cellNodesByColumnIdx[cellToRemove];
+      if (postProcessedRows[row]) {
+        delete postProcessedRows[row][cellToRemove];
       }
+      totalCellsRemoved++;
     }
+  }
 
-    function getContainerNode() {
-      return $container.get(0);
-    }
+  function cleanUpAndRenderCells(range) {
+    var cacheEntry;
+    var stringArray = [];
+    var processedRows = [];
+    var cellsAdded;
+    var totalCellsAdded = 0;
+    var colspan;
 
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    // Rendering / Scrolling
-
-    function getRowTop(row) {
-      return options.rowHeight * row - offset;
-    }
-
-    function getRowFromPosition(y) {
-      return Math.floor((y + offset) / options.rowHeight);
-    }
-
-    function scrollTo(y) {
-      y = Math.max(y, 0);
-      y = Math.min(y, th - viewportH + (viewportHasHScroll ? scrollbarDimensions.height : 0));
-
-      var oldOffset = offset;
-
-      page = Math.min(n - 1, Math.floor(y / ph));
-      offset = Math.round(page * cj);
-      var newScrollTop = y - offset;
-
-      if (offset != oldOffset) {
-        var range = getVisibleRange(newScrollTop);
-        cleanupRows(range);
-        updateRowPositions();
+    for (var row = range.top, btm = range.bottom; row <= btm; row++) {
+      cacheEntry = rowsCache[row];
+      if (!cacheEntry) {
+        continue;
       }
 
-      if (prevScrollTop != newScrollTop) {
-        vScrollDir = (prevScrollTop + oldOffset < newScrollTop + offset) ? 1 : -1;
-        $viewport[0].scrollTop = (lastRenderedScrollTop = scrollTop = prevScrollTop = newScrollTop);
+      // cellRenderQueue populated in renderRows() needs to be cleared first
+      ensureCellNodesInRowsCache(row);
 
-        trigger(self.onViewportChanged, {});
-      }
-    }
+      cleanUpCells(range, row);
 
-    function defaultFormatter(row, cell, value, columnDef, dataContext) {
-      if (value == null) {
-        return "";
-      } else {
-        return (value + "").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
-      }
-    }
-
-    function getFormatter(row, column) {
-      var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
-
-      // look up by id, then index
-      var columnOverrides = rowMetadata &&
-          rowMetadata.columns &&
-          (rowMetadata.columns[column.id] || rowMetadata.columns[getColumnIndex(column.id)]);
-
-      return (columnOverrides && columnOverrides.formatter) ||
-          (rowMetadata && rowMetadata.formatter) ||
-          column.formatter ||
-          (options.formatterFactory && options.formatterFactory.getFormatter(column)) ||
-          options.defaultFormatter;
-    }
-
-    function getEditor(row, cell) {
-      var column = columns[cell];
-      var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
-      var columnMetadata = rowMetadata && rowMetadata.columns;
-
-      if (columnMetadata && columnMetadata[column.id] && columnMetadata[column.id].editor !== undefined) {
-        return columnMetadata[column.id].editor;
-      }
-      if (columnMetadata && columnMetadata[cell] && columnMetadata[cell].editor !== undefined) {
-        return columnMetadata[cell].editor;
-      }
-
-      return column.editor || (options.editorFactory && options.editorFactory.getEditor(column));
-    }
-
-    function getDataItemValueForColumn(item, columnDef) {
-      if (options.dataItemColumnValueExtractor) {
-        return options.dataItemColumnValueExtractor(item, columnDef);
-      }
-      return item[columnDef.field];
-    }
-
-    function appendRowHtml(stringArray, row, range, dataLength) {
-      var d = getDataItem(row);
-      var dataLoading = row < dataLength && !d;
-      var rowCss = "slick-row" +
-          (dataLoading ? " loading" : "") +
-          (row === activeRow ? " active" : "") +
-          (row % 2 == 1 ? " odd" : " even");
-
-      if (!d) {
-        rowCss += " " + options.addNewRowCssClass;
-      }
+      // Render missing cells.
+      cellsAdded = 0;
 
       var metadata = data.getItemMetadata && data.getItemMetadata(row);
+      metadata = metadata && metadata.columns;
 
-      if (metadata && metadata.cssClasses) {
-        rowCss += " " + metadata.cssClasses;
-      }
+      var d = getDataItem(row);
 
-      stringArray.push("<div class='ui-widget-content " + rowCss + "' style='top:" + getRowTop(row) + "px'>");
-
-      var colspan, m;
+      // TODO:  shorten this loop (index? heuristics? binary search?)
       for (var i = 0, ii = columns.length; i < ii; i++) {
-        m = columns[i];
+        // Cells to the right are outside the range.
+        if (columnPosLeft[i] > range.rightPx) {
+          break;
+        }
+
+        // Already rendered.
+        if ((colspan = cacheEntry.cellColSpans[i]) != null) {
+          i += (colspan > 1 ? colspan - 1 : 0);
+          continue;
+        }
+
         colspan = 1;
-        if (metadata && metadata.columns) {
-          var columnData = metadata.columns[m.id] || metadata.columns[i];
+        if (metadata) {
+          var columnData = metadata[columns[i].id] || metadata[i];
           colspan = (columnData && columnData.colspan) || 1;
           if (colspan === "*") {
             colspan = ii - i;
           }
         }
 
-        // Do not render cells outside of the viewport.
         if (columnPosRight[Math.min(ii - 1, i + colspan - 1)] > range.leftPx) {
-          if (columnPosLeft[i] > range.rightPx) {
-            // All columns to the right are outside the range.
-            break;
-          }
-
           appendCellHtml(stringArray, row, i, colspan, d);
+          cellsAdded++;
         }
 
-        if (colspan > 1) {
-          i += (colspan - 1);
-        }
+        i += (colspan > 1 ? colspan - 1 : 0);
       }
 
-      stringArray.push("</div>");
-    }
-
-    function appendCellHtml(stringArray, row, cell, colspan, item) {
-      var m = columns[cell];
-      var cellCss = "slick-cell l" + cell + " r" + Math.min(columns.length - 1, cell + colspan - 1) +
-          (m.cssClass ? " " + m.cssClass : "");
-      if (row === activeRow && cell === activeCell) {
-        cellCss += (" active");
-      }
-
-      // TODO:  merge them together in the setter
-      for (var key in cellCssClasses) {
-        if (cellCssClasses[key][row] && cellCssClasses[key][row][m.id]) {
-          cellCss += (" " + cellCssClasses[key][row][m.id]);
-        }
-      }
-
-      stringArray.push("<div class='" + cellCss + "'>");
-
-      // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
-      if (item) {
-        var value = getDataItemValueForColumn(item, m);
-        stringArray.push(getFormatter(row, m)(row, cell, value, m, item));
-      }
-
-      stringArray.push("</div>");
-
-      rowsCache[row].cellRenderQueue.push(cell);
-      rowsCache[row].cellColSpans[cell] = colspan;
-    }
-
-
-    function cleanupRows(rangeToKeep) {
-      for (var i in rowsCache) {
-        if (((i = parseInt(i, 10)) !== activeRow) && (i < rangeToKeep.top || i > rangeToKeep.bottom)) {
-          removeRowFromCache(i);
-        }
+      if (cellsAdded) {
+        totalCellsAdded += cellsAdded;
+        processedRows.push(row);
       }
     }
 
-    function invalidate() {
-      updateRowCount();
-      invalidateAllRows();
-      render();
+    if (!stringArray.length) {
+      return;
     }
 
-    function invalidateAllRows() {
-      if (currentEditor) {
-        makeActiveCellNormal();
-      }
-      for (var row in rowsCache) {
-        removeRowFromCache(row);
+    var x = document.createElement("div");
+    x.innerHTML = stringArray.join("");
+
+    var processedRow;
+    var node;
+    while ((processedRow = processedRows.pop()) != null) {
+      cacheEntry = rowsCache[processedRow];
+      var columnIdx;
+      while ((columnIdx = cacheEntry.cellRenderQueue.pop()) != null) {
+        node = x.lastChild;
+        cacheEntry.rowNode.appendChild(node);
+        cacheEntry.cellNodesByColumnIdx[columnIdx] = node;
       }
     }
+  }
 
-    function removeRowFromCache(row) {
-      var cacheEntry = rowsCache[row];
-      if (!cacheEntry) {
-        return;
+  function renderRows(range) {
+    var parentNode = $canvas[0],
+        stringArray = [],
+        rows = [],
+        needToReselectCell = false,
+        dataLength = getDataLength();
+
+    for (var i = range.top, ii = range.bottom; i <= ii; i++) {
+      if (rowsCache[i]) {
+        continue;
       }
+      renderedRows++;
+      rows.push(i);
 
-      if (rowNodeFromLastMouseWheelEvent == cacheEntry.rowNode) {
-        cacheEntry.rowNode.style.display = 'none';
-        zombieRowNodeFromLastMouseWheelEvent = rowNodeFromLastMouseWheelEvent;
+      // Create an entry right away so that appendRowHtml() can
+      // start populatating it.
+      rowsCache[i] = {
+        "rowNode": null,
+
+        // ColSpans of rendered cells (by column idx).
+        // Can also be used for checking whether a cell has been rendered.
+        "cellColSpans": [],
+
+        // Cell nodes (by column idx).  Lazy-populated by ensureCellNodesInRowsCache().
+        "cellNodesByColumnIdx": [],
+
+        // Column indices of cell nodes that have been rendered, but not yet indexed in
+        // cellNodesByColumnIdx.  These are in the same order as cell nodes added at the
+        // end of the row.
+        "cellRenderQueue": []
+      };
+
+      appendRowHtml(stringArray, i, range, dataLength);
+      if (activeCellNode && activeRow === i) {
+        needToReselectCell = true;
+      }
+      counter_rows_rendered++;
+    }
+
+    if (!rows.length) { return; }
+
+    var x = document.createElement("div");
+    x.innerHTML = stringArray.join("");
+
+    for (var i = 0, ii = rows.length; i < ii; i++) {
+      rowsCache[rows[i]].rowNode = parentNode.appendChild(x.firstChild);
+    }
+
+    if (needToReselectCell) {
+      activeCellNode = getCellNode(activeRow, activeCell);
+    }
+  }
+
+  function startPostProcessing() {
+    if (!options.enableAsyncPostRender) {
+      return;
+    }
+    clearTimeout(h_postrender);
+    h_postrender = setTimeout(asyncPostProcessRows, options.asyncPostRenderDelay);
+  }
+
+  function invalidatePostProcessingResults(row) {
+    delete postProcessedRows[row];
+    postProcessFromRow = Math.min(postProcessFromRow, row);
+    postProcessToRow = Math.max(postProcessToRow, row);
+    startPostProcessing();
+  }
+
+  function updateRowPositions() {
+    for (var row in rowsCache) {
+      rowsCache[row].rowNode.style.top = getRowTop(row) + "px";
+    }
+  }
+
+  function render() {
+    if (!initialized) { return; }
+    var visible = getVisibleRange();
+    var rendered = getRenderedRange();
+
+    // remove rows no longer in the viewport
+    cleanupRows(rendered);
+
+    // add new rows & missing cells in existing rows
+    if (lastRenderedScrollLeft != scrollLeft) {
+      cleanUpAndRenderCells(rendered);
+    }
+
+    // render missing rows
+    renderRows(rendered);
+
+    postProcessFromRow = visible.top;
+    postProcessToRow = Math.min(getDataLengthIncludingAddNew() - 1, visible.bottom);
+    startPostProcessing();
+
+    lastRenderedScrollTop = scrollTop;
+    lastRenderedScrollLeft = scrollLeft;
+    h_render = null;
+  }
+
+  function handleHeaderRowScroll() {
+    var scrollLeft = $headerRowScroller[0].scrollLeft;
+    if (scrollLeft != $viewport[0].scrollLeft) {
+      $viewport[0].scrollLeft = scrollLeft;
+    }
+  }
+
+  function handleScroll() {
+    scrollTop = $viewport[0].scrollTop;
+    scrollLeft = $viewport[0].scrollLeft;
+    var vScrollDist = Math.abs(scrollTop - prevScrollTop);
+    var hScrollDist = Math.abs(scrollLeft - prevScrollLeft);
+
+    if (hScrollDist) {
+      prevScrollLeft = scrollLeft;
+      $headerScroller[0].scrollLeft = scrollLeft;
+      $topPanelScroller[0].scrollLeft = scrollLeft;
+      $headerRowScroller[0].scrollLeft = scrollLeft;
+    }
+
+    if (vScrollDist) {
+      vScrollDir = prevScrollTop < scrollTop ? 1 : -1;
+      prevScrollTop = scrollTop;
+
+      // switch virtual pages if needed
+      if (vScrollDist < viewportH) {
+        scrollTo(scrollTop + offset);
       } else {
-        $canvas[0].removeChild(cacheEntry.rowNode);
-      }
-
-      delete rowsCache[row];
-      delete postProcessedRows[row];
-      renderedRows--;
-      counter_rows_removed++;
-    }
-
-    function invalidateRows(rows) {
-      var i, rl;
-      if (!rows || !rows.length) {
-        return;
-      }
-      vScrollDir = 0;
-      for (i = 0, rl = rows.length; i < rl; i++) {
-        if (currentEditor && activeRow === rows[i]) {
-          makeActiveCellNormal();
+        var oldOffset = offset;
+        if (h == viewportH) {
+          page = 0;
+        } else {
+          page = Math.min(n - 1, Math.floor(scrollTop * ((th - viewportH) / (h - viewportH)) * (1 / ph)));
         }
-        if (rowsCache[rows[i]]) {
-          removeRowFromCache(rows[i]);
+        offset = Math.round(page * cj);
+        if (oldOffset != offset) {
+          invalidateAllRows();
         }
       }
     }
 
-    function invalidateRow(row) {
-      invalidateRows([row]);
-    }
-
-    function updateCell(row, cell) {
-      var cellNode = getCellNode(row, cell);
-      if (!cellNode) {
-        return;
+    if (hScrollDist || vScrollDist) {
+      if (h_render) {
+        clearTimeout(h_render);
       }
 
-      var m = columns[cell], d = getDataItem(row);
-      if (currentEditor && activeRow === row && activeCell === cell) {
-        currentEditor.loadValue(d);
-      } else {
-        cellNode.innerHTML = d ? getFormatter(row, m)(row, cell, getDataItemValueForColumn(d, m), m, d) : "";
-        invalidatePostProcessingResults(row);
+      if (Math.abs(lastRenderedScrollTop - scrollTop) > 20 ||
+          Math.abs(lastRenderedScrollLeft - scrollLeft) > 20) {
+        if (options.forceSyncScrolling || (
+            Math.abs(lastRenderedScrollTop - scrollTop) < viewportH &&
+            Math.abs(lastRenderedScrollLeft - scrollLeft) < viewportW)) {
+          render();
+        } else {
+          h_render = setTimeout(render, 50);
+        }
+
+        trigger(self.onViewportChanged, {});
       }
     }
 
-    function updateRow(row) {
+    trigger(self.onScroll, {scrollLeft: scrollLeft, scrollTop: scrollTop});
+  }
+
+  function asyncPostProcessRows() {
+    var dataLength = getDataLength();
+    while (postProcessFromRow <= postProcessToRow) {
+      var row = (vScrollDir >= 0) ? postProcessFromRow++ : postProcessToRow--;
       var cacheEntry = rowsCache[row];
-      if (!cacheEntry) {
-        return;
+      if (!cacheEntry || row >= dataLength) {
+        continue;
+      }
+
+      if (!postProcessedRows[row]) {
+        postProcessedRows[row] = {};
       }
 
       ensureCellNodesInRowsCache(row);
-
-      var d = getDataItem(row);
-
       for (var columnIdx in cacheEntry.cellNodesByColumnIdx) {
         if (!cacheEntry.cellNodesByColumnIdx.hasOwnProperty(columnIdx)) {
           continue;
         }
 
         columnIdx = columnIdx | 0;
-        var m = columns[columnIdx],
-            node = cacheEntry.cellNodesByColumnIdx[columnIdx];
 
-        if (row === activeRow && columnIdx === activeCell && currentEditor) {
-          currentEditor.loadValue(d);
-        } else if (d) {
-          node.innerHTML = getFormatter(row, m)(row, columnIdx, getDataItemValueForColumn(d, m), m, d);
-        } else {
-          node.innerHTML = "";
-        }
-      }
-
-      invalidatePostProcessingResults(row);
-    }
-
-    function getViewportHeight() {
-      return parseFloat($.css($container[0], "height", true)) -
-          parseFloat($.css($container[0], "paddingTop", true)) -
-          parseFloat($.css($container[0], "paddingBottom", true)) -
-          parseFloat($.css($headerScroller[0], "height")) - getVBoxDelta($headerScroller) -
-          (options.showTopPanel ? options.topPanelHeight + getVBoxDelta($topPanelScroller) : 0) -
-          (options.showHeaderRow ? options.headerRowHeight + getVBoxDelta($headerRowScroller) : 0);
-    }
-
-    function resizeCanvas() {
-      if (!initialized) { return; }
-      if (options.autoHeight) {
-        viewportH = options.rowHeight * getDataLengthIncludingAddNew();
-      } else {
-        viewportH = getViewportHeight();
-      }
-
-      numVisibleRows = Math.ceil(viewportH / options.rowHeight);
-      viewportW = parseFloat($.css($container[0], "width", true));
-      if (!options.autoHeight) {
-        $viewport.height(viewportH);
-      }
-
-      if (options.forceFitColumns) {
-        autosizeColumns();
-      }
-
-      updateRowCount();
-      handleScroll();
-      // Since the width has changed, force the render() to reevaluate virtually rendered cells.
-      lastRenderedScrollLeft = -1;
-      render();
-    }
-
-    function updateRowCount() {
-      if (!initialized) { return; }
-
-      var dataLengthIncludingAddNew = getDataLengthIncludingAddNew();
-      var numberOfRows = dataLengthIncludingAddNew +
-          (options.leaveSpaceForNewRows ? numVisibleRows - 1 : 0);
-
-      var oldViewportHasVScroll = viewportHasVScroll;
-      // with autoHeight, we do not need to accommodate the vertical scroll bar
-      viewportHasVScroll = !options.autoHeight && (numberOfRows * options.rowHeight > viewportH);
-
-      makeActiveCellNormal();
-
-      // remove the rows that are now outside of the data range
-      // this helps avoid redundant calls to .removeRow() when the size of the data decreased by thousands of rows
-      var l = dataLengthIncludingAddNew - 1;
-      for (var i in rowsCache) {
-        if (i >= l) {
-          removeRowFromCache(i);
-        }
-      }
-
-      if (activeCellNode && activeRow > l) {
-        resetActiveCell();
-      }
-
-      var oldH = h;
-      th = Math.max(options.rowHeight * numberOfRows, viewportH - scrollbarDimensions.height);
-      if (th < maxSupportedCssHeight) {
-        // just one page
-        h = ph = th;
-        n = 1;
-        cj = 0;
-      } else {
-        // break into pages
-        h = maxSupportedCssHeight;
-        ph = h / 100;
-        n = Math.floor(th / ph);
-        cj = (th - h) / (n - 1);
-      }
-
-      if (h !== oldH) {
-        $canvas.css("height", h);
-        scrollTop = $viewport[0].scrollTop;
-      }
-
-      var oldScrollTopInRange = (scrollTop + offset <= th - viewportH);
-
-      if (th == 0 || scrollTop == 0) {
-        page = offset = 0;
-      } else if (oldScrollTopInRange) {
-        // maintain virtual position
-        scrollTo(scrollTop + offset);
-      } else {
-        // scroll to bottom
-        scrollTo(th - viewportH);
-      }
-
-      if (h != oldH && options.autoHeight) {
-        resizeCanvas();
-      }
-
-      if (options.forceFitColumns && oldViewportHasVScroll != viewportHasVScroll) {
-        autosizeColumns();
-      }
-      updateCanvasWidth(false);
-    }
-
-    function getVisibleRange(viewportTop, viewportLeft) {
-      if (viewportTop == null) {
-        viewportTop = scrollTop;
-      }
-      if (viewportLeft == null) {
-        viewportLeft = scrollLeft;
-      }
-
-      return {
-        top: getRowFromPosition(viewportTop),
-        bottom: getRowFromPosition(viewportTop + viewportH) + 1,
-        leftPx: viewportLeft,
-        rightPx: viewportLeft + viewportW
-      };
-    }
-
-    function getRenderedRange(viewportTop, viewportLeft) {
-      var range = getVisibleRange(viewportTop, viewportLeft);
-      var buffer = Math.round(viewportH / options.rowHeight);
-      var minBuffer = 3;
-
-      if (vScrollDir == -1) {
-        range.top -= buffer;
-        range.bottom += minBuffer;
-      } else if (vScrollDir == 1) {
-        range.top -= minBuffer;
-        range.bottom += buffer;
-      } else {
-        range.top -= minBuffer;
-        range.bottom += minBuffer;
-      }
-
-      range.top = Math.max(0, range.top);
-      range.bottom = Math.min(getDataLengthIncludingAddNew() - 1, range.bottom);
-
-      range.leftPx -= viewportW;
-      range.rightPx += viewportW;
-
-      range.leftPx = Math.max(0, range.leftPx);
-      range.rightPx = Math.min(canvasWidth, range.rightPx);
-
-      return range;
-    }
-
-    function ensureCellNodesInRowsCache(row) {
-      var cacheEntry = rowsCache[row];
-      if (cacheEntry) {
-        if (cacheEntry.cellRenderQueue.length) {
-          var lastChild = cacheEntry.rowNode.lastChild;
-          while (cacheEntry.cellRenderQueue.length) {
-            var columnIdx = cacheEntry.cellRenderQueue.pop();
-            cacheEntry.cellNodesByColumnIdx[columnIdx] = lastChild;
-            lastChild = lastChild.previousSibling;
+        var m = columns[columnIdx];
+        if (m.asyncPostRender && !postProcessedRows[row][columnIdx]) {
+          var node = cacheEntry.cellNodesByColumnIdx[columnIdx];
+          if (node) {
+            m.asyncPostRender(node, row, getDataItem(row), m);
           }
-        }
-      }
-    }
-
-    function cleanUpCells(range, row) {
-      var totalCellsRemoved = 0;
-      var cacheEntry = rowsCache[row];
-
-      // Remove cells outside the range.
-      var cellsToRemove = [];
-      for (var i in cacheEntry.cellNodesByColumnIdx) {
-        // I really hate it when people mess with Array.prototype.
-        if (!cacheEntry.cellNodesByColumnIdx.hasOwnProperty(i)) {
-          continue;
-        }
-
-        // This is a string, so it needs to be cast back to a number.
-        i = i | 0;
-
-        var colspan = cacheEntry.cellColSpans[i];
-        if (columnPosLeft[i] > range.rightPx ||
-          columnPosRight[Math.min(columns.length - 1, i + colspan - 1)] < range.leftPx) {
-          if (!(row == activeRow && i == activeCell)) {
-            cellsToRemove.push(i);
-          }
+          postProcessedRows[row][columnIdx] = true;
         }
       }
 
-      var cellToRemove;
-      while ((cellToRemove = cellsToRemove.pop()) != null) {
-        cacheEntry.rowNode.removeChild(cacheEntry.cellNodesByColumnIdx[cellToRemove]);
-        delete cacheEntry.cellColSpans[cellToRemove];
-        delete cacheEntry.cellNodesByColumnIdx[cellToRemove];
-        if (postProcessedRows[row]) {
-          delete postProcessedRows[row][cellToRemove];
-        }
-        totalCellsRemoved++;
-      }
-    }
-
-    function cleanUpAndRenderCells(range) {
-      var cacheEntry;
-      var stringArray = [];
-      var processedRows = [];
-      var cellsAdded;
-      var totalCellsAdded = 0;
-      var colspan;
-
-      for (var row = range.top, btm = range.bottom; row <= btm; row++) {
-        cacheEntry = rowsCache[row];
-        if (!cacheEntry) {
-          continue;
-        }
-
-        // cellRenderQueue populated in renderRows() needs to be cleared first
-        ensureCellNodesInRowsCache(row);
-
-        cleanUpCells(range, row);
-
-        // Render missing cells.
-        cellsAdded = 0;
-
-        var metadata = data.getItemMetadata && data.getItemMetadata(row);
-        metadata = metadata && metadata.columns;
-
-        var d = getDataItem(row);
-
-        // TODO:  shorten this loop (index? heuristics? binary search?)
-        for (var i = 0, ii = columns.length; i < ii; i++) {
-          // Cells to the right are outside the range.
-          if (columnPosLeft[i] > range.rightPx) {
-            break;
-          }
-
-          // Already rendered.
-          if ((colspan = cacheEntry.cellColSpans[i]) != null) {
-            i += (colspan > 1 ? colspan - 1 : 0);
-            continue;
-          }
-
-          colspan = 1;
-          if (metadata) {
-            var columnData = metadata[columns[i].id] || metadata[i];
-            colspan = (columnData && columnData.colspan) || 1;
-            if (colspan === "*") {
-              colspan = ii - i;
-            }
-          }
-
-          if (columnPosRight[Math.min(ii - 1, i + colspan - 1)] > range.leftPx) {
-            appendCellHtml(stringArray, row, i, colspan, d);
-            cellsAdded++;
-          }
-
-          i += (colspan > 1 ? colspan - 1 : 0);
-        }
-
-        if (cellsAdded) {
-          totalCellsAdded += cellsAdded;
-          processedRows.push(row);
-        }
-      }
-
-      if (!stringArray.length) {
-        return;
-      }
-
-      var x = document.createElement("div");
-      x.innerHTML = stringArray.join("");
-
-      var processedRow;
-      var node;
-      while ((processedRow = processedRows.pop()) != null) {
-        cacheEntry = rowsCache[processedRow];
-        var columnIdx;
-        while ((columnIdx = cacheEntry.cellRenderQueue.pop()) != null) {
-          node = x.lastChild;
-          cacheEntry.rowNode.appendChild(node);
-          cacheEntry.cellNodesByColumnIdx[columnIdx] = node;
-        }
-      }
-    }
-
-    function renderRows(range) {
-      var parentNode = $canvas[0],
-          stringArray = [],
-          rows = [],
-          needToReselectCell = false,
-          dataLength = getDataLength();
-
-      for (var i = range.top, ii = range.bottom; i <= ii; i++) {
-        if (rowsCache[i]) {
-          continue;
-        }
-        renderedRows++;
-        rows.push(i);
-
-        // Create an entry right away so that appendRowHtml() can
-        // start populatating it.
-        rowsCache[i] = {
-          "rowNode": null,
-
-          // ColSpans of rendered cells (by column idx).
-          // Can also be used for checking whether a cell has been rendered.
-          "cellColSpans": [],
-
-          // Cell nodes (by column idx).  Lazy-populated by ensureCellNodesInRowsCache().
-          "cellNodesByColumnIdx": [],
-
-          // Column indices of cell nodes that have been rendered, but not yet indexed in
-          // cellNodesByColumnIdx.  These are in the same order as cell nodes added at the
-          // end of the row.
-          "cellRenderQueue": []
-        };
-
-        appendRowHtml(stringArray, i, range, dataLength);
-        if (activeCellNode && activeRow === i) {
-          needToReselectCell = true;
-        }
-        counter_rows_rendered++;
-      }
-
-      if (!rows.length) { return; }
-
-      var x = document.createElement("div");
-      x.innerHTML = stringArray.join("");
-
-      for (var i = 0, ii = rows.length; i < ii; i++) {
-        rowsCache[rows[i]].rowNode = parentNode.appendChild(x.firstChild);
-      }
-
-      if (needToReselectCell) {
-        activeCellNode = getCellNode(activeRow, activeCell);
-      }
-    }
-
-    function startPostProcessing() {
-      if (!options.enableAsyncPostRender) {
-        return;
-      }
-      clearTimeout(h_postrender);
       h_postrender = setTimeout(asyncPostProcessRows, options.asyncPostRenderDelay);
+      return;
     }
+  }
 
-    function invalidatePostProcessingResults(row) {
-      delete postProcessedRows[row];
-      postProcessFromRow = Math.min(postProcessFromRow, row);
-      postProcessToRow = Math.max(postProcessToRow, row);
-      startPostProcessing();
-    }
+  function updateCellCssStylesOnRenderedRows(addedHash, removedHash) {
+    var node, columnId, addedRowHash, removedRowHash;
+    for (var row in rowsCache) {
+      removedRowHash = removedHash && removedHash[row];
+      addedRowHash = addedHash && addedHash[row];
 
-    function updateRowPositions() {
-      for (var row in rowsCache) {
-        rowsCache[row].rowNode.style.top = getRowTop(row) + "px";
-      }
-    }
-
-    function render() {
-      if (!initialized) { return; }
-      var visible = getVisibleRange();
-      var rendered = getRenderedRange();
-
-      // remove rows no longer in the viewport
-      cleanupRows(rendered);
-
-      // add new rows & missing cells in existing rows
-      if (lastRenderedScrollLeft != scrollLeft) {
-        cleanUpAndRenderCells(rendered);
-      }
-
-      // render missing rows
-      renderRows(rendered);
-
-      postProcessFromRow = visible.top;
-      postProcessToRow = Math.min(getDataLengthIncludingAddNew() - 1, visible.bottom);
-      startPostProcessing();
-
-      lastRenderedScrollTop = scrollTop;
-      lastRenderedScrollLeft = scrollLeft;
-      h_render = null;
-    }
-
-    function handleHeaderRowScroll() {
-      var scrollLeft = $headerRowScroller[0].scrollLeft;
-      if (scrollLeft != $viewport[0].scrollLeft) {
-        $viewport[0].scrollLeft = scrollLeft;
-      }
-    }
-
-    function handleScroll() {
-      scrollTop = $viewport[0].scrollTop;
-      scrollLeft = $viewport[0].scrollLeft;
-      var vScrollDist = Math.abs(scrollTop - prevScrollTop);
-      var hScrollDist = Math.abs(scrollLeft - prevScrollLeft);
-
-      if (hScrollDist) {
-        prevScrollLeft = scrollLeft;
-        $headerScroller[0].scrollLeft = scrollLeft;
-        $topPanelScroller[0].scrollLeft = scrollLeft;
-        $headerRowScroller[0].scrollLeft = scrollLeft;
-      }
-
-      if (vScrollDist) {
-        vScrollDir = prevScrollTop < scrollTop ? 1 : -1;
-        prevScrollTop = scrollTop;
-
-        // switch virtual pages if needed
-        if (vScrollDist < viewportH) {
-          scrollTo(scrollTop + offset);
-        } else {
-          var oldOffset = offset;
-          if (h == viewportH) {
-            page = 0;
-          } else {
-            page = Math.min(n - 1, Math.floor(scrollTop * ((th - viewportH) / (h - viewportH)) * (1 / ph)));
-          }
-          offset = Math.round(page * cj);
-          if (oldOffset != offset) {
-            invalidateAllRows();
-          }
-        }
-      }
-
-      if (hScrollDist || vScrollDist) {
-        if (h_render) {
-          clearTimeout(h_render);
-        }
-
-        if (Math.abs(lastRenderedScrollTop - scrollTop) > 20 ||
-            Math.abs(lastRenderedScrollLeft - scrollLeft) > 20) {
-          if (options.forceSyncScrolling || (
-              Math.abs(lastRenderedScrollTop - scrollTop) < viewportH &&
-              Math.abs(lastRenderedScrollLeft - scrollLeft) < viewportW)) {
-            render();
-          } else {
-            h_render = setTimeout(render, 50);
-          }
-
-          trigger(self.onViewportChanged, {});
-        }
-      }
-
-      trigger(self.onScroll, {scrollLeft: scrollLeft, scrollTop: scrollTop});
-    }
-
-    function asyncPostProcessRows() {
-      var dataLength = getDataLength();
-      while (postProcessFromRow <= postProcessToRow) {
-        var row = (vScrollDir >= 0) ? postProcessFromRow++ : postProcessToRow--;
-        var cacheEntry = rowsCache[row];
-        if (!cacheEntry || row >= dataLength) {
-          continue;
-        }
-
-        if (!postProcessedRows[row]) {
-          postProcessedRows[row] = {};
-        }
-
-        ensureCellNodesInRowsCache(row);
-        for (var columnIdx in cacheEntry.cellNodesByColumnIdx) {
-          if (!cacheEntry.cellNodesByColumnIdx.hasOwnProperty(columnIdx)) {
-            continue;
-          }
-
-          columnIdx = columnIdx | 0;
-
-          var m = columns[columnIdx];
-          if (m.asyncPostRender && !postProcessedRows[row][columnIdx]) {
-            var node = cacheEntry.cellNodesByColumnIdx[columnIdx];
+      if (removedRowHash) {
+        for (columnId in removedRowHash) {
+          if (!addedRowHash || removedRowHash[columnId] != addedRowHash[columnId]) {
+            node = getCellNode(row, getColumnIndex(columnId));
             if (node) {
-              m.asyncPostRender(node, row, getDataItem(row), m);
+              $(node).removeClass(removedRowHash[columnId]);
             }
-            postProcessedRows[row][columnIdx] = true;
           }
         }
-
-        h_postrender = setTimeout(asyncPostProcessRows, options.asyncPostRenderDelay);
-        return;
       }
-    }
 
-    function updateCellCssStylesOnRenderedRows(addedHash, removedHash) {
-      var node, columnId, addedRowHash, removedRowHash;
-      for (var row in rowsCache) {
-        removedRowHash = removedHash && removedHash[row];
-        addedRowHash = addedHash && addedHash[row];
-
-        if (removedRowHash) {
-          for (columnId in removedRowHash) {
-            if (!addedRowHash || removedRowHash[columnId] != addedRowHash[columnId]) {
-              node = getCellNode(row, getColumnIndex(columnId));
-              if (node) {
-                $(node).removeClass(removedRowHash[columnId]);
-              }
-            }
-          }
-        }
-
-        if (addedRowHash) {
-          for (columnId in addedRowHash) {
-            if (!removedRowHash || removedRowHash[columnId] != addedRowHash[columnId]) {
-              node = getCellNode(row, getColumnIndex(columnId));
-              if (node) {
-                $(node).addClass(addedRowHash[columnId]);
-              }
+      if (addedRowHash) {
+        for (columnId in addedRowHash) {
+          if (!removedRowHash || removedRowHash[columnId] != addedRowHash[columnId]) {
+            node = getCellNode(row, getColumnIndex(columnId));
+            if (node) {
+              $(node).addClass(addedRowHash[columnId]);
             }
           }
         }
       }
     }
+  }
 
-    function addCellCssStyles(key, hash) {
-      if (cellCssClasses[key]) {
-        throw "addCellCssStyles: cell CSS hash with key '" + key + "' already exists.";
-      }
-
-      cellCssClasses[key] = hash;
-      updateCellCssStylesOnRenderedRows(hash, null);
-
-      trigger(self.onCellCssStylesChanged, { "key": key, "hash": hash });
+  function addCellCssStyles(key, hash) {
+    if (cellCssClasses[key]) {
+      throw "addCellCssStyles: cell CSS hash with key '" + key + "' already exists.";
     }
 
-    function removeCellCssStyles(key) {
-      if (!cellCssClasses[key]) {
-        return;
-      }
+    cellCssClasses[key] = hash;
+    updateCellCssStylesOnRenderedRows(hash, null);
 
-      updateCellCssStylesOnRenderedRows(null, cellCssClasses[key]);
-      delete cellCssClasses[key];
+    trigger(self.onCellCssStylesChanged, { "key": key, "hash": hash });
+  }
 
-      trigger(self.onCellCssStylesChanged, { "key": key, "hash": null });
+  function removeCellCssStyles(key) {
+    if (!cellCssClasses[key]) {
+      return;
     }
 
-    function setCellCssStyles(key, hash) {
-      var prevHash = cellCssClasses[key];
+    updateCellCssStylesOnRenderedRows(null, cellCssClasses[key]);
+    delete cellCssClasses[key];
 
-      cellCssClasses[key] = hash;
-      updateCellCssStylesOnRenderedRows(hash, prevHash);
+    trigger(self.onCellCssStylesChanged, { "key": key, "hash": null });
+  }
 
-      trigger(self.onCellCssStylesChanged, { "key": key, "hash": hash });
-    }
+  function setCellCssStyles(key, hash) {
+    var prevHash = cellCssClasses[key];
 
-    function getCellCssStyles(key) {
-      return cellCssClasses[key];
-    }
+    cellCssClasses[key] = hash;
+    updateCellCssStylesOnRenderedRows(hash, prevHash);
 
-    function flashCell(row, cell, speed) {
-      speed = speed || 100;
-      if (rowsCache[row]) {
-        var $cell = $(getCellNode(row, cell));
+    trigger(self.onCellCssStylesChanged, { "key": key, "hash": hash });
+  }
 
-        function toggleCellClass(times) {
-          if (!times) {
-            return;
-          }
-          setTimeout(function () {
-                $cell.queue(function () {
-                  $cell.toggleClass(options.cellFlashingCssClass).dequeue();
-                  toggleCellClass(times - 1);
-                });
-              },
-              speed);
+  function getCellCssStyles(key) {
+    return cellCssClasses[key];
+  }
+
+  function flashCell(row, cell, speed) {
+    speed = speed || 100;
+    if (rowsCache[row]) {
+      var $cell = $(getCellNode(row, cell));
+
+      function toggleCellClass(times) {
+        if (!times) {
+          return;
         }
-
-        toggleCellClass(4);
+        setTimeout(function () {
+              $cell.queue(function () {
+                $cell.toggleClass(options.cellFlashingCssClass).dequeue();
+                toggleCellClass(times - 1);
+              });
+            },
+            speed);
       }
+
+      toggleCellClass(4);
     }
+  }
 
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    // Interactivity
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // Interactivity
 
-    function handleMouseWheel(e) {
-      var rowNode = $(e.target).closest(".slick-row")[0];
-      if (rowNode != rowNodeFromLastMouseWheelEvent) {
-        if (zombieRowNodeFromLastMouseWheelEvent && zombieRowNodeFromLastMouseWheelEvent != rowNode) {
-          $canvas[0].removeChild(zombieRowNodeFromLastMouseWheelEvent);
-          zombieRowNodeFromLastMouseWheelEvent = null;
-        }
-        rowNodeFromLastMouseWheelEvent = rowNode;
+  function handleMouseWheel(e) {
+    var rowNode = $(e.target).closest(".slick-row")[0];
+    if (rowNode != rowNodeFromLastMouseWheelEvent) {
+      if (zombieRowNodeFromLastMouseWheelEvent && zombieRowNodeFromLastMouseWheelEvent != rowNode) {
+        $canvas[0].removeChild(zombieRowNodeFromLastMouseWheelEvent);
+        zombieRowNodeFromLastMouseWheelEvent = null;
       }
+      rowNodeFromLastMouseWheelEvent = rowNode;
     }
+  }
 
-    function handleDragInit(e, dd) {
-      var cell = getCellFromEvent(e);
-      if (!cell || !cellExists(cell.row, cell.cell)) {
-        return false;
-      }
-
-      var retval = trigger(self.onDragInit, dd, e);
-      if (e.isImmediatePropagationStopped()) {
-        return retval;
-      }
-
-      // if nobody claims to be handling drag'n'drop by stopping immediate propagation,
-      // cancel out of it
+  function handleDragInit(e, dd) {
+    var cell = getCellFromEvent(e);
+    if (!cell || !cellExists(cell.row, cell.cell)) {
       return false;
     }
 
-    function handleDragStart(e, dd) {
-      var cell = getCellFromEvent(e);
-      if (!cell || !cellExists(cell.row, cell.cell)) {
-        return false;
-      }
+    var retval = trigger(self.onDragInit, dd, e);
+    if (e.isImmediatePropagationStopped()) {
+      return retval;
+    }
 
-      var retval = trigger(self.onDragStart, dd, e);
-      if (e.isImmediatePropagationStopped()) {
-        return retval;
-      }
+    // if nobody claims to be handling drag'n'drop by stopping immediate propagation,
+    // cancel out of it
+    return false;
+  }
 
+  function handleDragStart(e, dd) {
+    var cell = getCellFromEvent(e);
+    if (!cell || !cellExists(cell.row, cell.cell)) {
       return false;
     }
 
-    function handleDrag(e, dd) {
-      return trigger(self.onDrag, dd, e);
+    var retval = trigger(self.onDragStart, dd, e);
+    if (e.isImmediatePropagationStopped()) {
+      return retval;
     }
 
-    function handleDragEnd(e, dd) {
-      trigger(self.onDragEnd, dd, e);
-    }
+    return false;
+  }
 
-    function handleKeyDown(e) {
-      trigger(self.onKeyDown, {row: activeRow, cell: activeCell}, e);
-      var handled = e.isImmediatePropagationStopped();
+  function handleDrag(e, dd) {
+    return trigger(self.onDrag, dd, e);
+  }
 
-      if (!handled) {
-        if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
-          if (e.which == 27) { // esc
-            if (!getEditorLock().isActive()) {
-              return; // no editing mode to cancel, allow bubbling and default processing (exit without cancelling the event)
-            }
-            cancelEditAndSetFocus();
-          } else if (e.which == 34) { // space
-            navigatePageDown();
-            handled = true;
-          } else if (e.which == 33) { // pageup
-            navigatePageUp();
-            handled = true;
-          } else if (e.which == 37) { // pagedown
-            handled = navigateLeft();
-          } else if (e.which == 39) { // left
-            handled = navigateRight();
-          } else if (e.which == 38) { // right
-            handled = navigateUp();
-          } else if (e.which == 40) { // down
-            handled = navigateDown();
-          } else if (e.which == 9) { // tab
-            handled = navigateNext();
-          } else if (e.which == 13) { // enter
-            if (options.editable) {
-              if (currentEditor) {
-                // adding new row
-                if (activeRow === getDataLength()) {
-                  navigateDown();
-                } else {
-                  commitEditAndSetFocus();
-                }
+  function handleDragEnd(e, dd) {
+    trigger(self.onDragEnd, dd, e);
+  }
+
+  function handleKeyDown(e) {
+    trigger(self.onKeyDown, {row: activeRow, cell: activeCell}, e);
+    var handled = e.isImmediatePropagationStopped();
+
+    if (!handled) {
+      if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
+        if (e.which == 27) { // esc
+          if (!getEditorLock().isActive()) {
+            return; // no editing mode to cancel, allow bubbling and default processing (exit without cancelling the event)
+          }
+          cancelEditAndSetFocus();
+        } else if (e.which == 34) { // space
+          navigatePageDown();
+          handled = true;
+        } else if (e.which == 33) { // pageup
+          navigatePageUp();
+          handled = true;
+        } else if (e.which == 37) { // pagedown
+          handled = navigateLeft();
+        } else if (e.which == 39) { // left
+          handled = navigateRight();
+        } else if (e.which == 38) { // right
+          handled = navigateUp();
+        } else if (e.which == 40) { // down
+          handled = navigateDown();
+        } else if (e.which == 9) { // tab
+          handled = navigateNext();
+        } else if (e.which == 13) { // enter
+          if (options.editable) {
+            if (currentEditor) {
+              // adding new row
+              if (activeRow === getDataLength()) {
+                navigateDown();
               } else {
-                if (getEditorLock().commitCurrentEdit()) {
-                  makeActiveCellEditable();
-                }
+                commitEditAndSetFocus();
+              }
+            } else {
+              if (getEditorLock().commitCurrentEdit()) {
+                makeActiveCellEditable();
               }
             }
-            handled = true;
           }
-        } else if (e.which == 9 && e.shiftKey && !e.ctrlKey && !e.altKey) {
-          handled = navigatePrev(); // shift tab
+          handled = true;
         }
-      }
-
-      if (handled) {
-        // the event has been handled so don't let parent element (bubbling/propagation) or browser (default) handle it
-        e.stopPropagation();
-        e.preventDefault();
-        try {
-          e.originalEvent.keyCode = 0; // prevent default behaviour for special keys in IE browsers (F3, F5, etc.)
-        }
-        // ignore exceptions - setting the original event's keycode throws access denied exception for "Ctrl"
-        // (hitting control key only, nothing else), "Shift" (maybe others)
-        catch (error) {
-        }
+      } else if (e.which == 9 && e.shiftKey && !e.ctrlKey && !e.altKey) {
+        handled = navigatePrev(); // shift tab
       }
     }
 
-    function handleClick(e) {
-      if (!currentEditor) {
-        // if this click resulted in some cell child node getting focus,
-        // don't steal it back - keyboard events will still bubble up
-        // IE9+ seems to default DIVs to tabIndex=0 instead of -1, so check for cell clicks directly.
-        if (e.target != document.activeElement || $(e.target).hasClass("slick-cell")) {
-          setFocus();
-        }
+    if (handled) {
+      // the event has been handled so don't let parent element (bubbling/propagation) or browser (default) handle it
+      e.stopPropagation();
+      e.preventDefault();
+      try {
+        e.originalEvent.keyCode = 0; // prevent default behaviour for special keys in IE browsers (F3, F5, etc.)
       }
-
-      var cell = getCellFromEvent(e);
-      if (!cell || (currentEditor !== null && activeRow == cell.row && activeCell == cell.cell)) {
-        return;
+      // ignore exceptions - setting the original event's keycode throws access denied exception for "Ctrl"
+      // (hitting control key only, nothing else), "Shift" (maybe others)
+      catch (error) {
       }
+    }
+  }
 
-      trigger(self.onClick, {row: cell.row, cell: cell.cell}, e);
-      if (e.isImmediatePropagationStopped()) {
-        return;
-      }
-
-      if ((activeCell != cell.cell || activeRow != cell.row) && canCellBeActive(cell.row, cell.cell)) {
-        if (!getEditorLock().isActive() || getEditorLock().commitCurrentEdit()) {
-          scrollRowIntoView(cell.row, false);
-          setActiveCellInternal(getCellNode(cell.row, cell.cell));
-        }
+  function handleClick(e) {
+    if (!currentEditor) {
+      // if this click resulted in some cell child node getting focus,
+      // don't steal it back - keyboard events will still bubble up
+      // IE9+ seems to default DIVs to tabIndex=0 instead of -1, so check for cell clicks directly.
+      if (e.target != document.activeElement || $(e.target).hasClass("slick-cell")) {
+        setFocus();
       }
     }
 
-    function handleContextMenu(e) {
-      var $cell = $(e.target).closest(".slick-cell", $canvas);
-      if ($cell.length === 0) {
-        return;
-      }
-
-      // are we editing this cell?
-      if (activeCellNode === $cell[0] && currentEditor !== null) {
-        return;
-      }
-
-      trigger(self.onContextMenu, {}, e);
+    var cell = getCellFromEvent(e);
+    if (!cell || (currentEditor !== null && activeRow == cell.row && activeCell == cell.cell)) {
+      return;
     }
 
-    function handleDblClick(e) {
-      var cell = getCellFromEvent(e);
-      if (!cell || (currentEditor !== null && activeRow == cell.row && activeCell == cell.cell)) {
-        return;
-      }
+    trigger(self.onClick, {row: cell.row, cell: cell.cell}, e);
+    if (e.isImmediatePropagationStopped()) {
+      return;
+    }
 
-      trigger(self.onDblClick, {row: cell.row, cell: cell.cell}, e);
-      if (e.isImmediatePropagationStopped()) {
-        return;
-      }
-
-      if (options.editable) {
-        gotoCell(cell.row, cell.cell, true);
+    if ((activeCell != cell.cell || activeRow != cell.row) && canCellBeActive(cell.row, cell.cell)) {
+      if (!getEditorLock().isActive() || getEditorLock().commitCurrentEdit()) {
+        scrollRowIntoView(cell.row, false);
+        setActiveCellInternal(getCellNode(cell.row, cell.cell));
       }
     }
+  }
 
-    function handleHeaderMouseEnter(e) {
-      trigger(self.onHeaderMouseEnter, {
-        "column": $(this).data("column")
-      }, e);
+  function handleContextMenu(e) {
+    var $cell = $(e.target).closest(".slick-cell", $canvas);
+    if ($cell.length === 0) {
+      return;
     }
 
-    function handleHeaderMouseLeave(e) {
-      trigger(self.onHeaderMouseLeave, {
-        "column": $(this).data("column")
-      }, e);
+    // are we editing this cell?
+    if (activeCellNode === $cell[0] && currentEditor !== null) {
+      return;
     }
 
-    function handleHeaderContextMenu(e) {
-      var $header = $(e.target).closest(".slick-header-column", ".slick-header-columns");
-      var column = $header && $header.data("column");
-      trigger(self.onHeaderContextMenu, {column: column}, e);
+    trigger(self.onContextMenu, {}, e);
+  }
+
+  function handleDblClick(e) {
+    var cell = getCellFromEvent(e);
+    if (!cell || (currentEditor !== null && activeRow == cell.row && activeCell == cell.cell)) {
+      return;
     }
 
-    function handleHeaderClick(e) {
-      var $header = $(e.target).closest(".slick-header-column", ".slick-header-columns");
-      var column = $header && $header.data("column");
-      if (column) {
-        trigger(self.onHeaderClick, {column: column}, e);
+    trigger(self.onDblClick, {row: cell.row, cell: cell.cell}, e);
+    if (e.isImmediatePropagationStopped()) {
+      return;
+    }
+
+    if (options.editable) {
+      gotoCell(cell.row, cell.cell, true);
+    }
+  }
+
+  function handleHeaderMouseEnter(e) {
+    trigger(self.onHeaderMouseEnter, {
+      "column": $(this).data("column")
+    }, e);
+  }
+
+  function handleHeaderMouseLeave(e) {
+    trigger(self.onHeaderMouseLeave, {
+      "column": $(this).data("column")
+    }, e);
+  }
+
+  function handleHeaderContextMenu(e) {
+    var $header = $(e.target).closest(".slick-header-column", ".slick-header-columns");
+    var column = $header && $header.data("column");
+    trigger(self.onHeaderContextMenu, {column: column}, e);
+  }
+
+  function handleHeaderClick(e) {
+    var $header = $(e.target).closest(".slick-header-column", ".slick-header-columns");
+    var column = $header && $header.data("column");
+    if (column) {
+      trigger(self.onHeaderClick, {column: column}, e);
+    }
+  }
+
+  function handleMouseEnter(e) {
+    trigger(self.onMouseEnter, {}, e);
+  }
+
+  function handleMouseLeave(e) {
+    trigger(self.onMouseLeave, {}, e);
+  }
+
+  function cellExists(row, cell) {
+    return !(row < 0 || row >= getDataLength() || cell < 0 || cell >= columns.length);
+  }
+
+  function getCellFromPoint(x, y) {
+    var row = getRowFromPosition(y);
+    var cell = 0;
+
+    var w = 0;
+    for (var i = 0; i < columns.length && w < x; i++) {
+      w += columns[i].width;
+      cell++;
+    }
+
+    if (cell < 0) {
+      cell = 0;
+    }
+
+    return {row: row, cell: cell - 1};
+  }
+
+  function getCellFromNode(cellNode) {
+    // read column number from .l<columnNumber> CSS class
+    var cls = /l\d+/.exec(cellNode.className);
+    if (!cls) {
+      throw "getCellFromNode: cannot get cell - " + cellNode.className;
+    }
+    return parseInt(cls[0].substr(1, cls[0].length - 1), 10);
+  }
+
+  function getRowFromNode(rowNode) {
+    for (var row in rowsCache) {
+      if (rowsCache[row].rowNode === rowNode) {
+        return row | 0;
       }
     }
 
-    function handleMouseEnter(e) {
-      trigger(self.onMouseEnter, {}, e);
-    }
+    return null;
+  }
 
-    function handleMouseLeave(e) {
-      trigger(self.onMouseLeave, {}, e);
-    }
-
-    function cellExists(row, cell) {
-      return !(row < 0 || row >= getDataLength() || cell < 0 || cell >= columns.length);
-    }
-
-    function getCellFromPoint(x, y) {
-      var row = getRowFromPosition(y);
-      var cell = 0;
-
-      var w = 0;
-      for (var i = 0; i < columns.length && w < x; i++) {
-        w += columns[i].width;
-        cell++;
-      }
-
-      if (cell < 0) {
-        cell = 0;
-      }
-
-      return {row: row, cell: cell - 1};
-    }
-
-    function getCellFromNode(cellNode) {
-      // read column number from .l<columnNumber> CSS class
-      var cls = /l\d+/.exec(cellNode.className);
-      if (!cls) {
-        throw "getCellFromNode: cannot get cell - " + cellNode.className;
-      }
-      return parseInt(cls[0].substr(1, cls[0].length - 1), 10);
-    }
-
-    function getRowFromNode(rowNode) {
-      for (var row in rowsCache) {
-        if (rowsCache[row].rowNode === rowNode) {
-          return row | 0;
-        }
-      }
-
+  function getCellFromEvent(e) {
+    var $cell = $(e.target).closest(".slick-cell", $canvas);
+    if (!$cell.length) {
       return null;
     }
 
-    function getCellFromEvent(e) {
-      var $cell = $(e.target).closest(".slick-cell", $canvas);
-      if (!$cell.length) {
-        return null;
-      }
+    var row = getRowFromNode($cell[0].parentNode);
+    var cell = getCellFromNode($cell[0]);
 
-      var row = getRowFromNode($cell[0].parentNode);
-      var cell = getCellFromNode($cell[0]);
-
-      if (row == null || cell == null) {
-        return null;
-      } else {
-        return {
-          "row": row,
-          "cell": cell
-        };
-      }
-    }
-
-    function getCellNodeBox(row, cell) {
-      if (!cellExists(row, cell)) {
-        return null;
-      }
-
-      var y1 = getRowTop(row);
-      var y2 = y1 + options.rowHeight - 1;
-      var x1 = 0;
-      for (var i = 0; i < cell; i++) {
-        x1 += columns[i].width;
-      }
-      var x2 = x1 + columns[cell].width;
-
+    if (row == null || cell == null) {
+      return null;
+    } else {
       return {
-        top: y1,
-        left: x1,
-        bottom: y2,
-        right: x2
+        "row": row,
+        "cell": cell
       };
     }
+  }
 
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    // Cell switching
-
-    function resetActiveCell() {
-      setActiveCellInternal(null, false);
+  function getCellNodeBox(row, cell) {
+    if (!cellExists(row, cell)) {
+      return null;
     }
 
-    function setFocus() {
-      if (tabbingDirection == -1) {
-        $focusSink[0].focus();
-      } else {
-        $focusSink2[0].focus();
+    var y1 = getRowTop(row);
+    var y2 = y1 + options.rowHeight - 1;
+    var x1 = 0;
+    for (var i = 0; i < cell; i++) {
+      x1 += columns[i].width;
+    }
+    var x2 = x1 + columns[cell].width;
+
+    return {
+      top: y1,
+      left: x1,
+      bottom: y2,
+      right: x2
+    };
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // Cell switching
+
+  function resetActiveCell() {
+    setActiveCellInternal(null, false);
+  }
+
+  function setFocus() {
+    if (tabbingDirection == -1) {
+      $focusSink[0].focus();
+    } else {
+      $focusSink2[0].focus();
+    }
+  }
+
+  function scrollCellIntoView(row, cell, doPaging) {
+    scrollRowIntoView(row, doPaging);
+
+    var colspan = getColspan(row, cell);
+    var left = columnPosLeft[cell],
+      right = columnPosRight[cell + (colspan > 1 ? colspan - 1 : 0)],
+      scrollRight = scrollLeft + viewportW;
+
+    if (left < scrollLeft) {
+      $viewport.scrollLeft(left);
+      handleScroll();
+      render();
+    } else if (right > scrollRight) {
+      $viewport.scrollLeft(Math.min(left, right - $viewport[0].clientWidth));
+      handleScroll();
+      render();
+    }
+  }
+
+  function setActiveCellInternal(newCell, opt_editMode) {
+    if (activeCellNode !== null) {
+      makeActiveCellNormal();
+      $(activeCellNode).removeClass("active");
+      if (rowsCache[activeRow]) {
+        $(rowsCache[activeRow].rowNode).removeClass("active");
       }
     }
 
-    function scrollCellIntoView(row, cell, doPaging) {
-      scrollRowIntoView(row, doPaging);
+    var activeCellChanged = (activeCellNode !== newCell);
+    activeCellNode = newCell;
 
-      var colspan = getColspan(row, cell);
-      var left = columnPosLeft[cell],
-        right = columnPosRight[cell + (colspan > 1 ? colspan - 1 : 0)],
-        scrollRight = scrollLeft + viewportW;
+    if (activeCellNode != null) {
+      activeRow = getRowFromNode(activeCellNode.parentNode);
+      activeCell = activePosX = getCellFromNode(activeCellNode);
 
-      if (left < scrollLeft) {
-        $viewport.scrollLeft(left);
-        handleScroll();
-        render();
-      } else if (right > scrollRight) {
-        $viewport.scrollLeft(Math.min(left, right - $viewport[0].clientWidth));
-        handleScroll();
-        render();
-      }
-    }
-
-    function setActiveCellInternal(newCell, opt_editMode) {
-      if (activeCellNode !== null) {
-        makeActiveCellNormal();
-        $(activeCellNode).removeClass("active");
-        if (rowsCache[activeRow]) {
-          $(rowsCache[activeRow].rowNode).removeClass("active");
-        }
+      if (opt_editMode == null) {
+        opt_editMode = (activeRow == getDataLength()) || options.autoEdit;
       }
 
-      var activeCellChanged = (activeCellNode !== newCell);
-      activeCellNode = newCell;
+      $(activeCellNode).addClass("active");
+      $(rowsCache[activeRow].rowNode).addClass("active");
 
-      if (activeCellNode != null) {
-        activeRow = getRowFromNode(activeCellNode.parentNode);
-        activeCell = activePosX = getCellFromNode(activeCellNode);
+      if (options.editable && opt_editMode && isCellPotentiallyEditable(activeRow, activeCell)) {
+        clearTimeout(h_editorLoader);
 
-        if (opt_editMode == null) {
-          opt_editMode = (activeRow == getDataLength()) || options.autoEdit;
-        }
-
-        $(activeCellNode).addClass("active");
-        $(rowsCache[activeRow].rowNode).addClass("active");
-
-        if (options.editable && opt_editMode && isCellPotentiallyEditable(activeRow, activeCell)) {
-          clearTimeout(h_editorLoader);
-
-          if (options.asyncEditorLoading) {
-            h_editorLoader = setTimeout(function () {
-              makeActiveCellEditable();
-            }, options.asyncEditorLoadDelay);
-          } else {
+        if (options.asyncEditorLoading) {
+          h_editorLoader = setTimeout(function () {
             makeActiveCellEditable();
-          }
-        }
-      } else {
-        activeRow = activeCell = null;
-      }
-
-      if (activeCellChanged) {
-        trigger(self.onActiveCellChanged, getActiveCell());
-      }
-    }
-
-    function clearTextSelection() {
-      if (document.selection && document.selection.empty) {
-        try {
-          //IE fails here if selected element is not in dom
-          document.selection.empty();
-        } catch (e) { }
-      } else if (window.getSelection) {
-        var sel = window.getSelection();
-        if (sel && sel.removeAllRanges) {
-          sel.removeAllRanges();
+          }, options.asyncEditorLoadDelay);
+        } else {
+          makeActiveCellEditable();
         }
       }
+    } else {
+      activeRow = activeCell = null;
     }
 
-    function isCellPotentiallyEditable(row, cell) {
-      var dataLength = getDataLength();
-      // is the data for this row loaded?
-      if (row < dataLength && !getDataItem(row)) {
-        return false;
-      }
+    if (activeCellChanged) {
+      trigger(self.onActiveCellChanged, getActiveCell());
+    }
+  }
 
-      // are we in the Add New row?  can we create new from this cell?
-      if (columns[cell].cannotTriggerInsert && row >= dataLength) {
-        return false;
+  function clearTextSelection() {
+    if (document.selection && document.selection.empty) {
+      try {
+        //IE fails here if selected element is not in dom
+        document.selection.empty();
+      } catch (e) { }
+    } else if (window.getSelection) {
+      var sel = window.getSelection();
+      if (sel && sel.removeAllRanges) {
+        sel.removeAllRanges();
       }
+    }
+  }
 
-      // does this cell have an editor?
-      if (!getEditor(row, cell)) {
-        return false;
-      }
-
-      return true;
+  function isCellPotentiallyEditable(row, cell) {
+    var dataLength = getDataLength();
+    // is the data for this row loaded?
+    if (row < dataLength && !getDataItem(row)) {
+      return false;
     }
 
-    function makeActiveCellNormal() {
-      if (!currentEditor) {
-        return;
-      }
-      trigger(self.onBeforeCellEditorDestroy, {editor: currentEditor});
-      currentEditor.destroy();
-      currentEditor = null;
-
-      if (activeCellNode) {
-        var d = getDataItem(activeRow);
-        $(activeCellNode).removeClass("editable invalid");
-        if (d) {
-          var column = columns[activeCell];
-          var formatter = getFormatter(activeRow, column);
-          activeCellNode.innerHTML = formatter(activeRow, activeCell, getDataItemValueForColumn(d, column), column, d);
-          invalidatePostProcessingResults(activeRow);
-        }
-      }
-
-      // if there previously was text selected on a page (such as selected text in the edit cell just removed),
-      // IE can't set focus to anything else correctly
-      if (navigator.userAgent.toLowerCase().match(/msie/)) {
-        clearTextSelection();
-      }
-
-      getEditorLock().deactivate(editController);
+    // are we in the Add New row?  can we create new from this cell?
+    if (columns[cell].cannotTriggerInsert && row >= dataLength) {
+      return false;
     }
 
-    function makeActiveCellEditable(editor) {
-      if (!activeCellNode) {
-        return;
-      }
-      if (!options.editable) {
-        throw "Grid : makeActiveCellEditable : should never get called when options.editable is false";
-      }
+    // does this cell have an editor?
+    if (!getEditor(row, cell)) {
+      return false;
+    }
 
-      // cancel pending async call if there is one
-      clearTimeout(h_editorLoader);
+    return true;
+  }
 
-      if (!isCellPotentiallyEditable(activeRow, activeCell)) {
-        return;
-      }
+  function makeActiveCellNormal() {
+    if (!currentEditor) {
+      return;
+    }
+    trigger(self.onBeforeCellEditorDestroy, {editor: currentEditor});
+    currentEditor.destroy();
+    currentEditor = null;
 
-      var columnDef = columns[activeCell];
-      var item = getDataItem(activeRow);
-
-      if (trigger(self.onBeforeEditCell, {row: activeRow, cell: activeCell, item: item, column: columnDef}) === false) {
-        setFocus();
-        return;
-      }
-
-      getEditorLock().activate(editController);
-      $(activeCellNode).addClass("editable");
-
-      // don't clear the cell if a custom editor is passed through
-      if (!editor) {
-        activeCellNode.innerHTML = "";
-      }
-
-      currentEditor = new (editor || getEditor(activeRow, activeCell))({
-        grid: self,
-        gridPosition: absBox($container[0]),
-        position: absBox(activeCellNode),
-        container: activeCellNode,
-        column: columnDef,
-        item: item || {},
-        commitChanges: commitEditAndSetFocus,
-        cancelChanges: cancelEditAndSetFocus
-      });
-
-      if (item) {
-        currentEditor.loadValue(item);
-      }
-
-      serializedEditorValue = currentEditor.serializeValue();
-
-      if (currentEditor.position) {
-        handleActiveCellPositionChange();
+    if (activeCellNode) {
+      var d = getDataItem(activeRow);
+      $(activeCellNode).removeClass("editable invalid");
+      if (d) {
+        var column = columns[activeCell];
+        var formatter = getFormatter(activeRow, column);
+        activeCellNode.innerHTML = formatter(activeRow, activeCell, getDataItemValueForColumn(d, column), column, d);
+        invalidatePostProcessingResults(activeRow);
       }
     }
 
-    function commitEditAndSetFocus() {
-      // if the commit fails, it would do so due to a validation error
-      // if so, do not steal the focus from the editor
-      if (getEditorLock().commitCurrentEdit()) {
-        setFocus();
-        if (options.autoEdit) {
-          navigateDown();
-        }
-      }
+    // if there previously was text selected on a page (such as selected text in the edit cell just removed),
+    // IE can't set focus to anything else correctly
+    if (navigator.userAgent.toLowerCase().match(/msie/)) {
+      clearTextSelection();
     }
 
-    function cancelEditAndSetFocus() {
-      if (getEditorLock().cancelCurrentEdit()) {
-        setFocus();
-      }
+    getEditorLock().deactivate(editController);
+  }
+
+  function makeActiveCellEditable(editor) {
+    if (!activeCellNode) {
+      return;
+    }
+    if (!options.editable) {
+      throw "Grid : makeActiveCellEditable : should never get called when options.editable is false";
     }
 
-    function absBox(elem) {
-      var box = {
-        top: elem.offsetTop,
-        left: elem.offsetLeft,
-        bottom: 0,
-        right: 0,
-        width: $(elem).outerWidth(),
-        height: $(elem).outerHeight(),
-        visible: true};
+    // cancel pending async call if there is one
+    clearTimeout(h_editorLoader);
+
+    if (!isCellPotentiallyEditable(activeRow, activeCell)) {
+      return;
+    }
+
+    var columnDef = columns[activeCell];
+    var item = getDataItem(activeRow);
+
+    if (trigger(self.onBeforeEditCell, {row: activeRow, cell: activeCell, item: item, column: columnDef}) === false) {
+      setFocus();
+      return;
+    }
+
+    getEditorLock().activate(editController);
+    $(activeCellNode).addClass("editable");
+
+    // don't clear the cell if a custom editor is passed through
+    if (!editor) {
+      activeCellNode.innerHTML = "";
+    }
+
+    currentEditor = new (editor || getEditor(activeRow, activeCell))({
+      grid: self,
+      gridPosition: absBox($container[0]),
+      position: absBox(activeCellNode),
+      container: activeCellNode,
+      column: columnDef,
+      item: item || {},
+      commitChanges: commitEditAndSetFocus,
+      cancelChanges: cancelEditAndSetFocus
+    });
+
+    if (item) {
+      currentEditor.loadValue(item);
+    }
+
+    serializedEditorValue = currentEditor.serializeValue();
+
+    if (currentEditor.position) {
+      handleActiveCellPositionChange();
+    }
+  }
+
+  function commitEditAndSetFocus() {
+    // if the commit fails, it would do so due to a validation error
+    // if so, do not steal the focus from the editor
+    if (getEditorLock().commitCurrentEdit()) {
+      setFocus();
+      if (options.autoEdit) {
+        navigateDown();
+      }
+    }
+  }
+
+  function cancelEditAndSetFocus() {
+    if (getEditorLock().cancelCurrentEdit()) {
+      setFocus();
+    }
+  }
+
+  function absBox(elem) {
+    var box = {
+      top: elem.offsetTop,
+      left: elem.offsetLeft,
+      bottom: 0,
+      right: 0,
+      width: $(elem).outerWidth(),
+      height: $(elem).outerHeight(),
+      visible: true};
+    box.bottom = box.top + box.height;
+    box.right = box.left + box.width;
+
+    // walk up the tree
+    var offsetParent = elem.offsetParent;
+    while ((elem = elem.parentNode) != document.body) {
+      if (box.visible && elem.scrollHeight != elem.offsetHeight && $(elem).css("overflowY") != "visible") {
+        box.visible = box.bottom > elem.scrollTop && box.top < elem.scrollTop + elem.clientHeight;
+      }
+
+      if (box.visible && elem.scrollWidth != elem.offsetWidth && $(elem).css("overflowX") != "visible") {
+        box.visible = box.right > elem.scrollLeft && box.left < elem.scrollLeft + elem.clientWidth;
+      }
+
+      box.left -= elem.scrollLeft;
+      box.top -= elem.scrollTop;
+
+      if (elem === offsetParent) {
+        box.left += elem.offsetLeft;
+        box.top += elem.offsetTop;
+        offsetParent = elem.offsetParent;
+      }
+
       box.bottom = box.top + box.height;
       box.right = box.left + box.width;
-
-      // walk up the tree
-      var offsetParent = elem.offsetParent;
-      while ((elem = elem.parentNode) != document.body) {
-        if (box.visible && elem.scrollHeight != elem.offsetHeight && $(elem).css("overflowY") != "visible") {
-          box.visible = box.bottom > elem.scrollTop && box.top < elem.scrollTop + elem.clientHeight;
-        }
-
-        if (box.visible && elem.scrollWidth != elem.offsetWidth && $(elem).css("overflowX") != "visible") {
-          box.visible = box.right > elem.scrollLeft && box.left < elem.scrollLeft + elem.clientWidth;
-        }
-
-        box.left -= elem.scrollLeft;
-        box.top -= elem.scrollTop;
-
-        if (elem === offsetParent) {
-          box.left += elem.offsetLeft;
-          box.top += elem.offsetTop;
-          offsetParent = elem.offsetParent;
-        }
-
-        box.bottom = box.top + box.height;
-        box.right = box.left + box.width;
-      }
-
-      return box;
     }
 
-    function getActiveCellPosition() {
-      return absBox(activeCellNode);
+    return box;
+  }
+
+  function getActiveCellPosition() {
+    return absBox(activeCellNode);
+  }
+
+  function getGridPosition() {
+    return absBox($container[0])
+  }
+
+  function handleActiveCellPositionChange() {
+    if (!activeCellNode) {
+      return;
     }
 
-    function getGridPosition() {
-      return absBox($container[0])
-    }
+    trigger(self.onActiveCellPositionChanged, {});
 
-    function handleActiveCellPositionChange() {
-      if (!activeCellNode) {
-        return;
-      }
-
-      trigger(self.onActiveCellPositionChanged, {});
-
-      if (currentEditor) {
-        var cellBox = getActiveCellPosition();
-        if (currentEditor.show && currentEditor.hide) {
-          if (!cellBox.visible) {
-            currentEditor.hide();
-          } else {
-            currentEditor.show();
-          }
-        }
-
-        if (currentEditor.position) {
-          currentEditor.position(cellBox);
-        }
-      }
-    }
-
-    function getCellEditor() {
-      return currentEditor;
-    }
-
-    function getActiveCell() {
-      if (!activeCellNode) {
-        return null;
-      } else {
-        return {row: activeRow, cell: activeCell};
-      }
-    }
-
-    function getActiveCellNode() {
-      return activeCellNode;
-    }
-
-    function scrollRowIntoView(row, doPaging) {
-      var rowAtTop = row * options.rowHeight;
-      var rowAtBottom = (row + 1) * options.rowHeight - viewportH + (viewportHasHScroll ? scrollbarDimensions.height : 0);
-
-      // need to page down?
-      if ((row + 1) * options.rowHeight > scrollTop + viewportH + offset) {
-        scrollTo(doPaging ? rowAtTop : rowAtBottom);
-        render();
-      }
-      // or page up?
-      else if (row * options.rowHeight < scrollTop + offset) {
-        scrollTo(doPaging ? rowAtBottom : rowAtTop);
-        render();
-      }
-    }
-
-    function scrollRowToTop(row) {
-      scrollTo(row * options.rowHeight);
-      render();
-    }
-
-    function scrollPage(dir) {
-      var deltaRows = dir * numVisibleRows;
-      scrollTo((getRowFromPosition(scrollTop) + deltaRows) * options.rowHeight);
-      render();
-
-      if (options.enableCellNavigation && activeRow != null) {
-        var row = activeRow + deltaRows;
-        var dataLengthIncludingAddNew = getDataLengthIncludingAddNew();
-        if (row >= dataLengthIncludingAddNew) {
-          row = dataLengthIncludingAddNew - 1;
-        }
-        if (row < 0) {
-          row = 0;
-        }
-
-        var cell = 0, prevCell = null;
-        var prevActivePosX = activePosX;
-        while (cell <= activePosX) {
-          if (canCellBeActive(row, cell)) {
-            prevCell = cell;
-          }
-          cell += getColspan(row, cell);
-        }
-
-        if (prevCell !== null) {
-          setActiveCellInternal(getCellNode(row, prevCell));
-          activePosX = prevActivePosX;
+    if (currentEditor) {
+      var cellBox = getActiveCellPosition();
+      if (currentEditor.show && currentEditor.hide) {
+        if (!cellBox.visible) {
+          currentEditor.hide();
         } else {
-          resetActiveCell();
+          currentEditor.show();
         }
       }
-    }
 
-    function navigatePageDown() {
-      scrollPage(1);
+      if (currentEditor.position) {
+        currentEditor.position(cellBox);
+      }
     }
+  }
 
-    function navigatePageUp() {
-      scrollPage(-1);
+  function getCellEditor() {
+    return currentEditor;
+  }
+
+  function getActiveCell() {
+    if (!activeCellNode) {
+      return null;
+    } else {
+      return {row: activeRow, cell: activeCell};
     }
+  }
 
-    function getColspan(row, cell) {
-      var metadata = data.getItemMetadata && data.getItemMetadata(row);
-      if (!metadata || !metadata.columns) {
-        return 1;
+  function getActiveCellNode() {
+    return activeCellNode;
+  }
+
+  function scrollRowIntoView(row, doPaging) {
+    var rowAtTop = row * options.rowHeight;
+    var rowAtBottom = (row + 1) * options.rowHeight - viewportH + (viewportHasHScroll ? scrollbarDimensions.height : 0);
+
+    // need to page down?
+    if ((row + 1) * options.rowHeight > scrollTop + viewportH + offset) {
+      scrollTo(doPaging ? rowAtTop : rowAtBottom);
+      render();
+    }
+    // or page up?
+    else if (row * options.rowHeight < scrollTop + offset) {
+      scrollTo(doPaging ? rowAtBottom : rowAtTop);
+      render();
+    }
+  }
+
+  function scrollRowToTop(row) {
+    scrollTo(row * options.rowHeight);
+    render();
+  }
+
+  function scrollPage(dir) {
+    var deltaRows = dir * numVisibleRows;
+    scrollTo((getRowFromPosition(scrollTop) + deltaRows) * options.rowHeight);
+    render();
+
+    if (options.enableCellNavigation && activeRow != null) {
+      var row = activeRow + deltaRows;
+      var dataLengthIncludingAddNew = getDataLengthIncludingAddNew();
+      if (row >= dataLengthIncludingAddNew) {
+        row = dataLengthIncludingAddNew - 1;
+      }
+      if (row < 0) {
+        row = 0;
       }
 
-      var columnData = metadata.columns[columns[cell].id] || metadata.columns[cell];
-      var colspan = (columnData && columnData.colspan);
-      if (colspan === "*") {
-        colspan = columns.length - cell;
-      } else {
-        colspan = colspan || 1;
-      }
-
-      return colspan;
-    }
-
-    function findFirstFocusableCell(row) {
-      var cell = 0;
-      while (cell < columns.length) {
+      var cell = 0, prevCell = null;
+      var prevActivePosX = activePosX;
+      while (cell <= activePosX) {
         if (canCellBeActive(row, cell)) {
-          return cell;
+          prevCell = cell;
         }
         cell += getColspan(row, cell);
       }
+
+      if (prevCell !== null) {
+        setActiveCellInternal(getCellNode(row, prevCell));
+        activePosX = prevActivePosX;
+      } else {
+        resetActiveCell();
+      }
+    }
+  }
+
+  function navigatePageDown() {
+    scrollPage(1);
+  }
+
+  function navigatePageUp() {
+    scrollPage(-1);
+  }
+
+  function getColspan(row, cell) {
+    var metadata = data.getItemMetadata && data.getItemMetadata(row);
+    if (!metadata || !metadata.columns) {
+      return 1;
+    }
+
+    var columnData = metadata.columns[columns[cell].id] || metadata.columns[cell];
+    var colspan = (columnData && columnData.colspan);
+    if (colspan === "*") {
+      colspan = columns.length - cell;
+    } else {
+      colspan = colspan || 1;
+    }
+
+    return colspan;
+  }
+
+  function findFirstFocusableCell(row) {
+    var cell = 0;
+    while (cell < columns.length) {
+      if (canCellBeActive(row, cell)) {
+        return cell;
+      }
+      cell += getColspan(row, cell);
+    }
+    return null;
+  }
+
+  function findLastFocusableCell(row) {
+    var cell = 0;
+    var lastFocusableCell = null;
+    while (cell < columns.length) {
+      if (canCellBeActive(row, cell)) {
+        lastFocusableCell = cell;
+      }
+      cell += getColspan(row, cell);
+    }
+    return lastFocusableCell;
+  }
+
+  function gotoRight(row, cell, posX) {
+    if (cell >= columns.length) {
       return null;
     }
 
-    function findLastFocusableCell(row) {
-      var cell = 0;
-      var lastFocusableCell = null;
-      while (cell < columns.length) {
-        if (canCellBeActive(row, cell)) {
-          lastFocusableCell = cell;
-        }
-        cell += getColspan(row, cell);
-      }
-      return lastFocusableCell;
+    do {
+      cell += getColspan(row, cell);
+    }
+    while (cell < columns.length && !canCellBeActive(row, cell));
+
+    if (cell < columns.length) {
+      return {
+        "row": row,
+        "cell": cell,
+        "posX": cell
+      };
+    }
+    return null;
+  }
+
+  function gotoLeft(row, cell, posX) {
+    if (cell <= 0) {
+      return null;
     }
 
-    function gotoRight(row, cell, posX) {
-      if (cell >= columns.length) {
+    var firstFocusableCell = findFirstFocusableCell(row);
+    if (firstFocusableCell === null || firstFocusableCell >= cell) {
+      return null;
+    }
+
+    var prev = {
+      "row": row,
+      "cell": firstFocusableCell,
+      "posX": firstFocusableCell
+    };
+    var pos;
+    while (true) {
+      pos = gotoRight(prev.row, prev.cell, prev.posX);
+      if (!pos) {
+        return null;
+      }
+      if (pos.cell >= cell) {
+        return prev;
+      }
+      prev = pos;
+    }
+  }
+
+  function gotoDown(row, cell, posX) {
+    var prevCell;
+    var dataLengthIncludingAddNew = getDataLengthIncludingAddNew();
+    while (true) {
+      if (++row >= dataLengthIncludingAddNew) {
         return null;
       }
 
-      do {
+      prevCell = cell = 0;
+      while (cell <= posX) {
+        prevCell = cell;
         cell += getColspan(row, cell);
       }
-      while (cell < columns.length && !canCellBeActive(row, cell));
 
-      if (cell < columns.length) {
+      if (canCellBeActive(row, prevCell)) {
+        return {
+          "row": row,
+          "cell": prevCell,
+          "posX": posX
+        };
+      }
+    }
+  }
+
+  function gotoUp(row, cell, posX) {
+    var prevCell;
+    while (true) {
+      if (--row < 0) {
+        return null;
+      }
+
+      prevCell = cell = 0;
+      while (cell <= posX) {
+        prevCell = cell;
+        cell += getColspan(row, cell);
+      }
+
+      if (canCellBeActive(row, prevCell)) {
+        return {
+          "row": row,
+          "cell": prevCell,
+          "posX": posX
+        };
+      }
+    }
+  }
+
+  function gotoNext(row, cell, posX) {
+    if (row == null && cell == null) {
+      row = cell = posX = 0;
+      if (canCellBeActive(row, cell)) {
         return {
           "row": row,
           "cell": cell,
           "posX": cell
         };
       }
-      return null;
     }
 
-    function gotoLeft(row, cell, posX) {
-      if (cell <= 0) {
-        return null;
-      }
-
-      var firstFocusableCell = findFirstFocusableCell(row);
-      if (firstFocusableCell === null || firstFocusableCell >= cell) {
-        return null;
-      }
-
-      var prev = {
-        "row": row,
-        "cell": firstFocusableCell,
-        "posX": firstFocusableCell
-      };
-      var pos;
-      while (true) {
-        pos = gotoRight(prev.row, prev.cell, prev.posX);
-        if (!pos) {
-          return null;
-        }
-        if (pos.cell >= cell) {
-          return prev;
-        }
-        prev = pos;
-      }
-    }
-
-    function gotoDown(row, cell, posX) {
-      var prevCell;
-      var dataLengthIncludingAddNew = getDataLengthIncludingAddNew();
-      while (true) {
-        if (++row >= dataLengthIncludingAddNew) {
-          return null;
-        }
-
-        prevCell = cell = 0;
-        while (cell <= posX) {
-          prevCell = cell;
-          cell += getColspan(row, cell);
-        }
-
-        if (canCellBeActive(row, prevCell)) {
-          return {
-            "row": row,
-            "cell": prevCell,
-            "posX": posX
-          };
-        }
-      }
-    }
-
-    function gotoUp(row, cell, posX) {
-      var prevCell;
-      while (true) {
-        if (--row < 0) {
-          return null;
-        }
-
-        prevCell = cell = 0;
-        while (cell <= posX) {
-          prevCell = cell;
-          cell += getColspan(row, cell);
-        }
-
-        if (canCellBeActive(row, prevCell)) {
-          return {
-            "row": row,
-            "cell": prevCell,
-            "posX": posX
-          };
-        }
-      }
-    }
-
-    function gotoNext(row, cell, posX) {
-      if (row == null && cell == null) {
-        row = cell = posX = 0;
-        if (canCellBeActive(row, cell)) {
-          return {
-            "row": row,
-            "cell": cell,
-            "posX": cell
-          };
-        }
-      }
-
-      var pos = gotoRight(row, cell, posX);
-      if (pos) {
-        return pos;
-      }
-
-      var firstFocusableCell = null;
-      var dataLengthIncludingAddNew = getDataLengthIncludingAddNew();
-      while (++row < dataLengthIncludingAddNew) {
-        firstFocusableCell = findFirstFocusableCell(row);
-        if (firstFocusableCell !== null) {
-          return {
-            "row": row,
-            "cell": firstFocusableCell,
-            "posX": firstFocusableCell
-          };
-        }
-      }
-      return null;
-    }
-
-    function gotoPrev(row, cell, posX) {
-      if (row == null && cell == null) {
-        row = getDataLengthIncludingAddNew() - 1;
-        cell = posX = columns.length - 1;
-        if (canCellBeActive(row, cell)) {
-          return {
-            "row": row,
-            "cell": cell,
-            "posX": cell
-          };
-        }
-      }
-
-      var pos;
-      var lastSelectableCell;
-      while (!pos) {
-        pos = gotoLeft(row, cell, posX);
-        if (pos) {
-          break;
-        }
-        if (--row < 0) {
-          return null;
-        }
-
-        cell = 0;
-        lastSelectableCell = findLastFocusableCell(row);
-        if (lastSelectableCell !== null) {
-          pos = {
-            "row": row,
-            "cell": lastSelectableCell,
-            "posX": lastSelectableCell
-          };
-        }
-      }
+    var pos = gotoRight(row, cell, posX);
+    if (pos) {
       return pos;
     }
 
-    function navigateRight() {
-      return navigate("right");
-    }
-
-    function navigateLeft() {
-      return navigate("left");
-    }
-
-    function navigateDown() {
-      return navigate("down");
-    }
-
-    function navigateUp() {
-      return navigate("up");
-    }
-
-    function navigateNext() {
-      return navigate("next");
-    }
-
-    function navigatePrev() {
-      return navigate("prev");
-    }
-
-    /**
-     * @param {string} dir Navigation direction.
-     * @return {boolean} Whether navigation resulted in a change of active cell.
-     */
-    function navigate(dir) {
-      if (!options.enableCellNavigation) {
-        return false;
+    var firstFocusableCell = null;
+    var dataLengthIncludingAddNew = getDataLengthIncludingAddNew();
+    while (++row < dataLengthIncludingAddNew) {
+      firstFocusableCell = findFirstFocusableCell(row);
+      if (firstFocusableCell !== null) {
+        return {
+          "row": row,
+          "cell": firstFocusableCell,
+          "posX": firstFocusableCell
+        };
       }
+    }
+    return null;
+  }
 
-      if (!activeCellNode && dir != "prev" && dir != "next") {
-        return false;
+  function gotoPrev(row, cell, posX) {
+    if (row == null && cell == null) {
+      row = getDataLengthIncludingAddNew() - 1;
+      cell = posX = columns.length - 1;
+      if (canCellBeActive(row, cell)) {
+        return {
+          "row": row,
+          "cell": cell,
+          "posX": cell
+        };
       }
+    }
 
-      if (!getEditorLock().commitCurrentEdit()) {
-        return true;
-      }
-
-      if (options.editable) {
-        // steals focus from other controls on row navigation
-        setFocus();
-      }
-
-      var tabbingDirections = {
-        "up": -1,
-        "down": 1,
-        "left": -1,
-        "right": 1,
-        "prev": -1,
-        "next": 1
-      };
-      tabbingDirection = tabbingDirections[dir];
-
-      var stepFunctions = {
-        "up": gotoUp,
-        "down": gotoDown,
-        "left": gotoLeft,
-        "right": gotoRight,
-        "prev": gotoPrev,
-        "next": gotoNext
-      };
-      var stepFn = stepFunctions[dir];
-      var pos = stepFn(activeRow, activeCell, activePosX);
+    var pos;
+    var lastSelectableCell;
+    while (!pos) {
+      pos = gotoLeft(row, cell, posX);
       if (pos) {
-        var isAddNewRow = (pos.row == getDataLength());
-        scrollCellIntoView(pos.row, pos.cell, !isAddNewRow);
-        setActiveCellInternal(getCellNode(pos.row, pos.cell));
-        activePosX = pos.posX;
-        return true;
-      } else {
-        setActiveCellInternal(getCellNode(activeRow, activeCell));
-        return false;
+        break;
+      }
+      if (--row < 0) {
+        return null;
+      }
+
+      cell = 0;
+      lastSelectableCell = findLastFocusableCell(row);
+      if (lastSelectableCell !== null) {
+        pos = {
+          "row": row,
+          "cell": lastSelectableCell,
+          "posX": lastSelectableCell
+        };
       }
     }
+    return pos;
+  }
 
-    function getCellNode(row, cell) {
-      if (rowsCache[row]) {
-        ensureCellNodesInRowsCache(row);
-        return rowsCache[row].cellNodesByColumnIdx[cell];
-      }
-      return null;
+  function navigateRight() {
+    return navigate("right");
+  }
+
+  function navigateLeft() {
+    return navigate("left");
+  }
+
+  function navigateDown() {
+    return navigate("down");
+  }
+
+  function navigateUp() {
+    return navigate("up");
+  }
+
+  function navigateNext() {
+    return navigate("next");
+  }
+
+  function navigatePrev() {
+    return navigate("prev");
+  }
+
+  /**
+   * @param {string} dir Navigation direction.
+   * @return {boolean} Whether navigation resulted in a change of active cell.
+   */
+  function navigate(dir) {
+    if (!options.enableCellNavigation) {
+      return false;
     }
 
-    function setActiveCell(row, cell) {
-      if (!initialized) { return; }
-      if (row > getDataLength() || row < 0 || cell >= columns.length || cell < 0) {
-        return;
-      }
-
-      if (!options.enableCellNavigation) {
-        return;
-      }
-
-      scrollCellIntoView(row, cell, false);
-      setActiveCellInternal(getCellNode(row, cell), false);
+    if (!activeCellNode && dir != "prev" && dir != "next") {
+      return false;
     }
 
-    function canCellBeActive(row, cell) {
-      if (!options.enableCellNavigation || row >= getDataLengthIncludingAddNew() ||
-          row < 0 || cell >= columns.length || cell < 0) {
-        return false;
-      }
-
-      var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
-      if (rowMetadata && typeof rowMetadata.focusable === "boolean") {
-        return rowMetadata.focusable;
-      }
-
-      var columnMetadata = rowMetadata && rowMetadata.columns;
-      if (columnMetadata && columnMetadata[columns[cell].id] && typeof columnMetadata[columns[cell].id].focusable === "boolean") {
-        return columnMetadata[columns[cell].id].focusable;
-      }
-      if (columnMetadata && columnMetadata[cell] && typeof columnMetadata[cell].focusable === "boolean") {
-        return columnMetadata[cell].focusable;
-      }
-
-      return columns[cell].focusable;
+    if (!getEditorLock().commitCurrentEdit()) {
+      return true;
     }
 
-    function canCellBeSelected(row, cell) {
-      if (row >= getDataLength() || row < 0 || cell >= columns.length || cell < 0) {
-        return false;
-      }
-
-      var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
-      if (rowMetadata && typeof rowMetadata.selectable === "boolean") {
-        return rowMetadata.selectable;
-      }
-
-      var columnMetadata = rowMetadata && rowMetadata.columns && (rowMetadata.columns[columns[cell].id] || rowMetadata.columns[cell]);
-      if (columnMetadata && typeof columnMetadata.selectable === "boolean") {
-        return columnMetadata.selectable;
-      }
-
-      return columns[cell].selectable;
+    if (options.editable) {
+      // steals focus from other controls on row navigation
+      setFocus();
     }
 
-    function gotoCell(row, cell, forceEdit) {
-      if (!initialized) { return; }
-      if (!canCellBeActive(row, cell)) {
-        return;
-      }
+    var tabbingDirections = {
+      "up": -1,
+      "down": 1,
+      "left": -1,
+      "right": 1,
+      "prev": -1,
+      "next": 1
+    };
+    tabbingDirection = tabbingDirections[dir];
 
-      if (!getEditorLock().commitCurrentEdit()) {
-        return;
-      }
+    var stepFunctions = {
+      "up": gotoUp,
+      "down": gotoDown,
+      "left": gotoLeft,
+      "right": gotoRight,
+      "prev": gotoPrev,
+      "next": gotoNext
+    };
+    var stepFn = stepFunctions[dir];
+    var pos = stepFn(activeRow, activeCell, activePosX);
+    if (pos) {
+      var isAddNewRow = (pos.row == getDataLength());
+      scrollCellIntoView(pos.row, pos.cell, !isAddNewRow);
+      setActiveCellInternal(getCellNode(pos.row, pos.cell));
+      activePosX = pos.posX;
+      return true;
+    } else {
+      setActiveCellInternal(getCellNode(activeRow, activeCell));
+      return false;
+    }
+  }
 
-      scrollCellIntoView(row, cell, false);
+  function getCellNode(row, cell) {
+    if (rowsCache[row]) {
+      ensureCellNodesInRowsCache(row);
+      return rowsCache[row].cellNodesByColumnIdx[cell];
+    }
+    return null;
+  }
 
-      var newCell = getCellNode(row, cell);
-
-      // if selecting the 'add new' row, start editing right away
-      setActiveCellInternal(newCell, forceEdit || (row === getDataLength()) || options.autoEdit);
-
-      // if no editor was created, set the focus back on the grid
-      if (!options.editable && $canvas.find(":focus").length !== 0) {
-        // steals focus when a row is programatically updated
-        setFocus();
-      }
+  function setActiveCell(row, cell) {
+    if (!initialized) { return; }
+    if (row > getDataLength() || row < 0 || cell >= columns.length || cell < 0) {
+      return;
     }
 
+    if (!options.enableCellNavigation) {
+      return;
+    }
 
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    // IEditor implementation for the editor lock
+    scrollCellIntoView(row, cell, false);
+    setActiveCellInternal(getCellNode(row, cell), false);
+  }
 
-    function commitCurrentEdit() {
-      var item = getDataItem(activeRow);
-      var column = columns[activeCell];
+  function canCellBeActive(row, cell) {
+    if (!options.enableCellNavigation || row >= getDataLengthIncludingAddNew() ||
+        row < 0 || cell >= columns.length || cell < 0) {
+      return false;
+    }
 
-      if (currentEditor) {
-        if (currentEditor.isValueChanged()) {
-          var validationResults = currentEditor.validate();
+    var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
+    if (rowMetadata && typeof rowMetadata.focusable === "boolean") {
+      return rowMetadata.focusable;
+    }
 
-          if (validationResults.valid) {
-            if (activeRow < getDataLength()) {
-              var editCommand = {
-                row: activeRow,
-                cell: activeCell,
-                editor: currentEditor,
-                serializedValue: currentEditor.serializeValue(),
-                prevSerializedValue: serializedEditorValue,
-                execute: function () {
-                  this.editor.applyValue(item, this.serializedValue);
-                  updateRow(this.row);
-                  trigger(self.onCellChange, {
-                    row: activeRow,
-                    cell: activeCell,
-                    item: item
-                  });
-                },
-                undo: function () {
-                  this.editor.applyValue(item, this.prevSerializedValue);
-                  updateRow(this.row);
-                  trigger(self.onCellChange, {
-                    row: activeRow,
-                    cell: activeCell,
-                    item: item
-                  });
-                }
-              };
+    var columnMetadata = rowMetadata && rowMetadata.columns;
+    if (columnMetadata && columnMetadata[columns[cell].id] && typeof columnMetadata[columns[cell].id].focusable === "boolean") {
+      return columnMetadata[columns[cell].id].focusable;
+    }
+    if (columnMetadata && columnMetadata[cell] && typeof columnMetadata[cell].focusable === "boolean") {
+      return columnMetadata[cell].focusable;
+    }
 
-              if (options.editCommandHandler) {
-                makeActiveCellNormal();
-                options.editCommandHandler(item, column, editCommand);
-              } else {
-                editCommand.execute();
-                makeActiveCellNormal();
-              }
+    return columns[cell].focusable;
+  }
 
-            } else {
-              var newItem = {};
-              currentEditor.applyValue(newItem, currentEditor.serializeValue());
-              makeActiveCellNormal();
-              trigger(self.onAddNewRow, {item: newItem, column: column});
-            }
+  function canCellBeSelected(row, cell) {
+    if (row >= getDataLength() || row < 0 || cell >= columns.length || cell < 0) {
+      return false;
+    }
 
-            // check whether the lock has been re-acquired by event handlers
-            return !getEditorLock().isActive();
-          } else {
-            // Re-add the CSS class to trigger transitions, if any.
-            $(activeCellNode).removeClass("invalid");
-            $(activeCellNode).width();  // force layout
-            $(activeCellNode).addClass("invalid");
+    var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
+    if (rowMetadata && typeof rowMetadata.selectable === "boolean") {
+      return rowMetadata.selectable;
+    }
 
-            trigger(self.onValidationError, {
-              editor: currentEditor,
-              cellNode: activeCellNode,
-              validationResults: validationResults,
+    var columnMetadata = rowMetadata && rowMetadata.columns && (rowMetadata.columns[columns[cell].id] || rowMetadata.columns[cell]);
+    if (columnMetadata && typeof columnMetadata.selectable === "boolean") {
+      return columnMetadata.selectable;
+    }
+
+    return columns[cell].selectable;
+  }
+
+  function gotoCell(row, cell, forceEdit) {
+    if (!initialized) { return; }
+    if (!canCellBeActive(row, cell)) {
+      return;
+    }
+
+    if (!getEditorLock().commitCurrentEdit()) {
+      return;
+    }
+
+    scrollCellIntoView(row, cell, false);
+
+    var newCell = getCellNode(row, cell);
+
+    // if selecting the 'add new' row, start editing right away
+    setActiveCellInternal(newCell, forceEdit || (row === getDataLength()) || options.autoEdit);
+
+    // if no editor was created, set the focus back on the grid
+    if (!options.editable && $canvas.find(":focus").length !== 0) {
+      // steals focus when a row is programatically updated
+      setFocus();
+    }
+  }
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // IEditor implementation for the editor lock
+
+  function commitCurrentEdit() {
+    var item = getDataItem(activeRow);
+    var column = columns[activeCell];
+
+    if (currentEditor) {
+      if (currentEditor.isValueChanged()) {
+        var validationResults = currentEditor.validate();
+
+        if (validationResults.valid) {
+          if (activeRow < getDataLength()) {
+            var editCommand = {
               row: activeRow,
               cell: activeCell,
-              column: column
-            });
+              editor: currentEditor,
+              serializedValue: currentEditor.serializeValue(),
+              prevSerializedValue: serializedEditorValue,
+              execute: function () {
+                this.editor.applyValue(item, this.serializedValue);
+                updateRow(this.row);
+                trigger(self.onCellChange, {
+                  row: activeRow,
+                  cell: activeCell,
+                  item: item
+                });
+              },
+              undo: function () {
+                this.editor.applyValue(item, this.prevSerializedValue);
+                updateRow(this.row);
+                trigger(self.onCellChange, {
+                  row: activeRow,
+                  cell: activeCell,
+                  item: item
+                });
+              }
+            };
 
-            currentEditor.focus();
-            return false;
+            if (options.editCommandHandler) {
+              makeActiveCellNormal();
+              options.editCommandHandler(item, column, editCommand);
+            } else {
+              editCommand.execute();
+              makeActiveCellNormal();
+            }
+
+          } else {
+            var newItem = {};
+            currentEditor.applyValue(newItem, currentEditor.serializeValue());
+            makeActiveCellNormal();
+            trigger(self.onAddNewRow, {item: newItem, column: column});
           }
+
+          // check whether the lock has been re-acquired by event handlers
+          return !getEditorLock().isActive();
+        } else {
+          // Re-add the CSS class to trigger transitions, if any.
+          $(activeCellNode).removeClass("invalid");
+          $(activeCellNode).width();  // force layout
+          $(activeCellNode).addClass("invalid");
+
+          trigger(self.onValidationError, {
+            editor: currentEditor,
+            cellNode: activeCellNode,
+            validationResults: validationResults,
+            row: activeRow,
+            cell: activeCell,
+            column: column
+          });
+
+          currentEditor.focus();
+          return false;
         }
-
-        makeActiveCellNormal();
       }
-      return true;
-    }
 
-    function cancelCurrentEdit() {
       makeActiveCellNormal();
-      return true;
     }
-
-    function rowsToRanges(rows) {
-      var ranges = [];
-      var lastCell = columns.length - 1;
-      for (var i = 0; i < rows.length; i++) {
-        ranges.push(new Slick.Range(rows[i], 0, rows[i], lastCell));
-      }
-      return ranges;
-    }
-
-    function getSelectedRows() {
-      if (!selectionModel) {
-        throw "Selection model is not set";
-      }
-      return selectedRows;
-    }
-
-    function setSelectedRows(rows) {
-      if (!selectionModel) {
-        throw "Selection model is not set";
-      }
-      selectionModel.setSelectedRanges(rowsToRanges(rows));
-    }
-
-
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    // Debug
-
-    this.debug = function () {
-      var s = "";
-
-      s += ("\n" + "counter_rows_rendered:  " + counter_rows_rendered);
-      s += ("\n" + "counter_rows_removed:  " + counter_rows_removed);
-      s += ("\n" + "renderedRows:  " + renderedRows);
-      s += ("\n" + "numVisibleRows:  " + numVisibleRows);
-      s += ("\n" + "maxSupportedCssHeight:  " + maxSupportedCssHeight);
-      s += ("\n" + "n(umber of pages):  " + n);
-      s += ("\n" + "(current) page:  " + page);
-      s += ("\n" + "page height (ph):  " + ph);
-      s += ("\n" + "vScrollDir:  " + vScrollDir);
-
-      alert(s);
-    };
-
-    // a debug helper to be able to access private members
-    this.eval = function (expr) {
-      return eval(expr);
-    };
-
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    // Public API
-
-    $.extend(this, {
-      "slickGridVersion": "2.1",
-
-      // Events
-      "onScroll": new Slick.Event(),
-      "onSort": new Slick.Event(),
-      "onHeaderMouseEnter": new Slick.Event(),
-      "onHeaderMouseLeave": new Slick.Event(),
-      "onHeaderContextMenu": new Slick.Event(),
-      "onHeaderClick": new Slick.Event(),
-      "onHeaderCellRendered": new Slick.Event(),
-      "onBeforeHeaderCellDestroy": new Slick.Event(),
-      "onHeaderRowCellRendered": new Slick.Event(),
-      "onBeforeHeaderRowCellDestroy": new Slick.Event(),
-      "onMouseEnter": new Slick.Event(),
-      "onMouseLeave": new Slick.Event(),
-      "onClick": new Slick.Event(),
-      "onDblClick": new Slick.Event(),
-      "onContextMenu": new Slick.Event(),
-      "onKeyDown": new Slick.Event(),
-      "onAddNewRow": new Slick.Event(),
-      "onValidationError": new Slick.Event(),
-      "onViewportChanged": new Slick.Event(),
-      "onColumnsReordered": new Slick.Event(),
-      "onColumnsResized": new Slick.Event(),
-      "onCellChange": new Slick.Event(),
-      "onBeforeEditCell": new Slick.Event(),
-      "onBeforeCellEditorDestroy": new Slick.Event(),
-      "onBeforeDestroy": new Slick.Event(),
-      "onActiveCellChanged": new Slick.Event(),
-      "onActiveCellPositionChanged": new Slick.Event(),
-      "onDragInit": new Slick.Event(),
-      "onDragStart": new Slick.Event(),
-      "onDrag": new Slick.Event(),
-      "onDragEnd": new Slick.Event(),
-      "onSelectedRowsChanged": new Slick.Event(),
-      "onCellCssStylesChanged": new Slick.Event(),
-
-      // Methods
-      "registerPlugin": registerPlugin,
-      "unregisterPlugin": unregisterPlugin,
-      "getColumns": getColumns,
-      "setColumns": setColumns,
-      "getColumnIndex": getColumnIndex,
-      "updateColumnHeader": updateColumnHeader,
-      "setSortColumn": setSortColumn,
-      "setSortColumns": setSortColumns,
-      "getSortColumns": getSortColumns,
-      "autosizeColumns": autosizeColumns,
-      "getOptions": getOptions,
-      "setOptions": setOptions,
-      "getData": getData,
-      "getDataLength": getDataLength,
-      "getDataItem": getDataItem,
-      "setData": setData,
-      "getSelectionModel": getSelectionModel,
-      "setSelectionModel": setSelectionModel,
-      "getSelectedRows": getSelectedRows,
-      "setSelectedRows": setSelectedRows,
-      "getContainerNode": getContainerNode,
-
-      "render": render,
-      "invalidate": invalidate,
-      "invalidateRow": invalidateRow,
-      "invalidateRows": invalidateRows,
-      "invalidateAllRows": invalidateAllRows,
-      "updateCell": updateCell,
-      "updateRow": updateRow,
-      "getViewport": getVisibleRange,
-      "getRenderedRange": getRenderedRange,
-      "resizeCanvas": resizeCanvas,
-      "updateRowCount": updateRowCount,
-      "scrollRowIntoView": scrollRowIntoView,
-      "scrollRowToTop": scrollRowToTop,
-      "scrollCellIntoView": scrollCellIntoView,
-      "getCanvasNode": getCanvasNode,
-      "focus": setFocus,
-
-      "getCellFromPoint": getCellFromPoint,
-      "getCellFromEvent": getCellFromEvent,
-      "getActiveCell": getActiveCell,
-      "setActiveCell": setActiveCell,
-      "getActiveCellNode": getActiveCellNode,
-      "getActiveCellPosition": getActiveCellPosition,
-      "resetActiveCell": resetActiveCell,
-      "editActiveCell": makeActiveCellEditable,
-      "getCellEditor": getCellEditor,
-      "getCellNode": getCellNode,
-      "getCellNodeBox": getCellNodeBox,
-      "canCellBeSelected": canCellBeSelected,
-      "canCellBeActive": canCellBeActive,
-      "navigatePrev": navigatePrev,
-      "navigateNext": navigateNext,
-      "navigateUp": navigateUp,
-      "navigateDown": navigateDown,
-      "navigateLeft": navigateLeft,
-      "navigateRight": navigateRight,
-      "navigatePageUp": navigatePageUp,
-      "navigatePageDown": navigatePageDown,
-      "gotoCell": gotoCell,
-      "getTopPanel": getTopPanel,
-      "setTopPanelVisibility": setTopPanelVisibility,
-      "setHeaderRowVisibility": setHeaderRowVisibility,
-      "getHeaderRow": getHeaderRow,
-      "getHeaderRowColumn": getHeaderRowColumn,
-      "getGridPosition": getGridPosition,
-      "flashCell": flashCell,
-      "addCellCssStyles": addCellCssStyles,
-      "setCellCssStyles": setCellCssStyles,
-      "removeCellCssStyles": removeCellCssStyles,
-      "getCellCssStyles": getCellCssStyles,
-
-      "init": finishInitialization,
-      "destroy": destroy,
-
-      // IEditor implementation
-      "getEditorLock": getEditorLock,
-      "getEditController": getEditController
-    });
-
-    init();
+    return true;
   }
-}(jQuery));
+
+  function cancelCurrentEdit() {
+    makeActiveCellNormal();
+    return true;
+  }
+
+  function rowsToRanges(rows) {
+    var ranges = [];
+    var lastCell = columns.length - 1;
+    for (var i = 0; i < rows.length; i++) {
+      ranges.push(new Slick.Range(rows[i], 0, rows[i], lastCell));
+    }
+    return ranges;
+  }
+
+  function getSelectedRows() {
+    if (!selectionModel) {
+      throw "Selection model is not set";
+    }
+    return selectedRows;
+  }
+
+  function setSelectedRows(rows) {
+    if (!selectionModel) {
+      throw "Selection model is not set";
+    }
+    selectionModel.setSelectedRanges(rowsToRanges(rows));
+  }
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // Debug
+
+  this.debug = function () {
+    var s = "";
+
+    s += ("\n" + "counter_rows_rendered:  " + counter_rows_rendered);
+    s += ("\n" + "counter_rows_removed:  " + counter_rows_removed);
+    s += ("\n" + "renderedRows:  " + renderedRows);
+    s += ("\n" + "numVisibleRows:  " + numVisibleRows);
+    s += ("\n" + "maxSupportedCssHeight:  " + maxSupportedCssHeight);
+    s += ("\n" + "n(umber of pages):  " + n);
+    s += ("\n" + "(current) page:  " + page);
+    s += ("\n" + "page height (ph):  " + ph);
+    s += ("\n" + "vScrollDir:  " + vScrollDir);
+
+    alert(s);
+  };
+
+  // a debug helper to be able to access private members
+  this.eval = function (expr) {
+    return eval(expr);
+  };
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // Public API
+
+  $.extend(this, {
+    "slickGridVersion": "2.1",
+
+    // Events
+    "onScroll": new Slick.Event(),
+    "onSort": new Slick.Event(),
+    "onHeaderMouseEnter": new Slick.Event(),
+    "onHeaderMouseLeave": new Slick.Event(),
+    "onHeaderContextMenu": new Slick.Event(),
+    "onHeaderClick": new Slick.Event(),
+    "onHeaderCellRendered": new Slick.Event(),
+    "onBeforeHeaderCellDestroy": new Slick.Event(),
+    "onHeaderRowCellRendered": new Slick.Event(),
+    "onBeforeHeaderRowCellDestroy": new Slick.Event(),
+    "onMouseEnter": new Slick.Event(),
+    "onMouseLeave": new Slick.Event(),
+    "onClick": new Slick.Event(),
+    "onDblClick": new Slick.Event(),
+    "onContextMenu": new Slick.Event(),
+    "onKeyDown": new Slick.Event(),
+    "onAddNewRow": new Slick.Event(),
+    "onValidationError": new Slick.Event(),
+    "onViewportChanged": new Slick.Event(),
+    "onColumnsReordered": new Slick.Event(),
+    "onColumnsResized": new Slick.Event(),
+    "onCellChange": new Slick.Event(),
+    "onBeforeEditCell": new Slick.Event(),
+    "onBeforeCellEditorDestroy": new Slick.Event(),
+    "onBeforeDestroy": new Slick.Event(),
+    "onActiveCellChanged": new Slick.Event(),
+    "onActiveCellPositionChanged": new Slick.Event(),
+    "onDragInit": new Slick.Event(),
+    "onDragStart": new Slick.Event(),
+    "onDrag": new Slick.Event(),
+    "onDragEnd": new Slick.Event(),
+    "onSelectedRowsChanged": new Slick.Event(),
+    "onCellCssStylesChanged": new Slick.Event(),
+
+    // Methods
+    "registerPlugin": registerPlugin,
+    "unregisterPlugin": unregisterPlugin,
+    "getColumns": getColumns,
+    "setColumns": setColumns,
+    "getColumnIndex": getColumnIndex,
+    "updateColumnHeader": updateColumnHeader,
+    "setSortColumn": setSortColumn,
+    "setSortColumns": setSortColumns,
+    "getSortColumns": getSortColumns,
+    "autosizeColumns": autosizeColumns,
+    "getOptions": getOptions,
+    "setOptions": setOptions,
+    "getData": getData,
+    "getDataLength": getDataLength,
+    "getDataItem": getDataItem,
+    "setData": setData,
+    "getSelectionModel": getSelectionModel,
+    "setSelectionModel": setSelectionModel,
+    "getSelectedRows": getSelectedRows,
+    "setSelectedRows": setSelectedRows,
+    "getContainerNode": getContainerNode,
+
+    "render": render,
+    "invalidate": invalidate,
+    "invalidateRow": invalidateRow,
+    "invalidateRows": invalidateRows,
+    "invalidateAllRows": invalidateAllRows,
+    "updateCell": updateCell,
+    "updateRow": updateRow,
+    "getViewport": getVisibleRange,
+    "getRenderedRange": getRenderedRange,
+    "resizeCanvas": resizeCanvas,
+    "updateRowCount": updateRowCount,
+    "scrollRowIntoView": scrollRowIntoView,
+    "scrollRowToTop": scrollRowToTop,
+    "scrollCellIntoView": scrollCellIntoView,
+    "getCanvasNode": getCanvasNode,
+    "focus": setFocus,
+
+    "getCellFromPoint": getCellFromPoint,
+    "getCellFromEvent": getCellFromEvent,
+    "getActiveCell": getActiveCell,
+    "setActiveCell": setActiveCell,
+    "getActiveCellNode": getActiveCellNode,
+    "getActiveCellPosition": getActiveCellPosition,
+    "resetActiveCell": resetActiveCell,
+    "editActiveCell": makeActiveCellEditable,
+    "getCellEditor": getCellEditor,
+    "getCellNode": getCellNode,
+    "getCellNodeBox": getCellNodeBox,
+    "canCellBeSelected": canCellBeSelected,
+    "canCellBeActive": canCellBeActive,
+    "navigatePrev": navigatePrev,
+    "navigateNext": navigateNext,
+    "navigateUp": navigateUp,
+    "navigateDown": navigateDown,
+    "navigateLeft": navigateLeft,
+    "navigateRight": navigateRight,
+    "navigatePageUp": navigatePageUp,
+    "navigatePageDown": navigatePageDown,
+    "gotoCell": gotoCell,
+    "getTopPanel": getTopPanel,
+    "setTopPanelVisibility": setTopPanelVisibility,
+    "setHeaderRowVisibility": setHeaderRowVisibility,
+    "getHeaderRow": getHeaderRow,
+    "getHeaderRowColumn": getHeaderRowColumn,
+    "getGridPosition": getGridPosition,
+    "flashCell": flashCell,
+    "addCellCssStyles": addCellCssStyles,
+    "setCellCssStyles": setCellCssStyles,
+    "removeCellCssStyles": removeCellCssStyles,
+    "getCellCssStyles": getCellCssStyles,
+
+    "init": finishInitialization,
+    "destroy": destroy,
+
+    // IEditor implementation
+    "getEditorLock": getEditorLock,
+    "getEditController": getEditController
+  });
+
+  init();
+}

--- a/grid.js
+++ b/grid.js
@@ -16,6 +16,8 @@
  *     and do proper cleanup.
  */
 
+var jQuery = require("jquery");
+
 // make sure required JavaScript modules are loaded
 if (typeof jQuery === "undefined") {
   throw "SlickGrid requires jquery module to be loaded";

--- a/lib/jquery-ui-1.10.1.custom.js
+++ b/lib/jquery-ui-1.10.1.custom.js
@@ -3,6 +3,8 @@
 * Includes: jquery.ui.core.js, jquery.ui.widget.js, jquery.ui.mouse.js, jquery.ui.sortable.js
 * Copyright (c) 2013 jQuery Foundation and other contributors Licensed MIT */
 
+var jQuery = require("jquery");
+
 (function( $, undefined ) {
 
 var uuid = 0,

--- a/lib/jquery-ui-1.10.1.custom.js
+++ b/lib/jquery-ui-1.10.1.custom.js
@@ -3,9 +3,9 @@
 * Includes: jquery.ui.core.js, jquery.ui.widget.js, jquery.ui.mouse.js, jquery.ui.sortable.js
 * Copyright (c) 2013 jQuery Foundation and other contributors Licensed MIT */
 
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function( $, undefined ) {
+(function( undefined ) {
 
 var uuid = 0,
 	runiqueId = /^ui-id-\d+$/;
@@ -318,8 +318,8 @@ $.extend( $.ui, {
 	}
 });
 
-})( jQuery );
-(function( $, undefined ) {
+})();
+(function( undefined ) {
 
 var uuid = 0,
 	slice = Array.prototype.slice,
@@ -829,8 +829,8 @@ $.each( { show: "fadeIn", hide: "fadeOut" }, function( method, defaultEffect ) {
 	};
 });
 
-})( jQuery );
-(function( $, undefined ) {
+})();
+(function( undefined ) {
 
 var mouseHandled = false;
 $( document ).mouseup( function() {
@@ -985,8 +985,8 @@ $.widget("ui.mouse", {
 	_mouseCapture: function(/* event */) { return true; }
 });
 
-})(jQuery);
-(function( $, undefined ) {
+})();
+(function( undefined ) {
 
 /*jshint loopfunc: true */
 
@@ -2220,4 +2220,4 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 });
 
-})(jQuery);
+})();

--- a/lib/jquery.event.drag-2.2.js
+++ b/lib/jquery.event.drag-2.2.js
@@ -7,9 +7,8 @@
 // Updated: 2012-05-21
 // REQUIRES: jquery 1.7.x
 
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-;(function( $ ){
 
 // add the jquery instance method
 $.fn.drag = function( str, arg, opts ){
@@ -400,5 +399,3 @@ $event.fixHooks.touchcancel = {
 
 // share the same special event configuration with related events...
 $special.draginit = $special.dragstart = $special.dragend = drag;
-
-})( jQuery );

--- a/lib/jquery.event.drag-2.2.js
+++ b/lib/jquery.event.drag-2.2.js
@@ -1,11 +1,13 @@
-/*! 
+/*!
  * jquery.event.drag - v 2.2
  * Copyright (c) 2010 Three Dub Media - http://threedubmedia.com
  * Open Source MIT License - http://threedubmedia.com/code/license
  */
-// Created: 2008-06-04 
+// Created: 2008-06-04
 // Updated: 2012-05-21
 // REQUIRES: jquery 1.7.x
+
+var jQuery = require("jquery");
 
 ;(function( $ ){
 
@@ -16,7 +18,7 @@ $.fn.drag = function( str, arg, opts ){
 	// figure out the event handler...
 	fn = $.isFunction( str ) ? str : $.isFunction( arg ) ? arg : null;
 	// fix the event type
-	if ( type.indexOf("drag") !== 0 ) 
+	if ( type.indexOf("drag") !== 0 )
 		type = "drag"+ type;
 	// were options passed
 	opts = ( str == fn ? arg : opts ) || {};
@@ -25,11 +27,11 @@ $.fn.drag = function( str, arg, opts ){
 };
 
 // local refs (increase compression)
-var $event = $.event, 
+var $event = $.event,
 $special = $event.special,
-// configure the drag special event 
+// configure the drag special event
 drag = $special.drag = {
-	
+
 	// these are the default settings
 	defaults: {
 		which: 1, // mouse button pressed to start drag sequence
@@ -40,38 +42,38 @@ drag = $special.drag = {
 		drop: true, // false to suppress drop events, true or selector to allow
 		click: false // false to suppress click events after dragend (no proxy)
 	},
-	
+
 	// the key name for stored drag data
 	datakey: "dragdata",
-	
+
 	// prevent bubbling for better performance
 	noBubble: true,
-	
+
 	// count bound related events
-	add: function( obj ){ 
+	add: function( obj ){
 		// read the interaction data
 		var data = $.data( this, drag.datakey ),
-		// read any passed options 
+		// read any passed options
 		opts = obj.data || {};
 		// count another realted event
 		data.related += 1;
 		// extend data options bound with this event
-		// don't iterate "opts" in case it is a node 
+		// don't iterate "opts" in case it is a node
 		$.each( drag.defaults, function( key, def ){
 			if ( opts[ key ] !== undefined )
 				data[ key ] = opts[ key ];
 		});
 	},
-	
+
 	// forget unbound related events
 	remove: function(){
 		$.data( this, drag.datakey ).related -= 1;
 	},
-	
+
 	// configure interaction, capture settings
 	setup: function(){
 		// check for related events
-		if ( $.data( this, drag.datakey ) ) 
+		if ( $.data( this, drag.datakey ) )
 			return;
 		// initialize the drag data with copied defaults
 		var data = $.extend({ related:0 }, drag.defaults );
@@ -80,42 +82,42 @@ drag = $special.drag = {
 		// bind the mousedown event, which starts drag interactions
 		$event.add( this, "touchstart mousedown", drag.init, data );
 		// prevent image dragging in IE...
-		if ( this.attachEvent ) 
-			this.attachEvent("ondragstart", drag.dontstart ); 
+		if ( this.attachEvent )
+			this.attachEvent("ondragstart", drag.dontstart );
 	},
-	
+
 	// destroy configured interaction
 	teardown: function(){
 		var data = $.data( this, drag.datakey ) || {};
 		// check for related events
-		if ( data.related ) 
+		if ( data.related )
 			return;
 		// remove the stored data
 		$.removeData( this, drag.datakey );
 		// remove the mousedown event
 		$event.remove( this, "touchstart mousedown", drag.init );
 		// enable text selection
-		drag.textselect( true ); 
+		drag.textselect( true );
 		// un-prevent image dragging in IE...
-		if ( this.detachEvent ) 
-			this.detachEvent("ondragstart", drag.dontstart ); 
+		if ( this.detachEvent )
+			this.detachEvent("ondragstart", drag.dontstart );
 	},
-		
+
 	// initialize the interaction
-	init: function( event ){ 
+	init: function( event ){
 		// sorry, only one touch at a time
-		if ( drag.touched ) 
+		if ( drag.touched )
 			return;
 		// the drag/drop interaction data
 		var dd = event.data, results;
 		// check the which directive
-		if ( event.which != 0 && dd.which > 0 && event.which != dd.which ) 
-			return; 
+		if ( event.which != 0 && dd.which > 0 && event.which != dd.which )
+			return;
 		// check for suppressed selector
-		if ( $( event.target ).is( dd.not ) ) 
+		if ( $( event.target ).is( dd.not ) )
 			return;
 		// check for handle selector
-		if ( dd.handle && !$( event.target ).closest( dd.handle, event.currentTarget ).length ) 
+		if ( dd.handle && !$( event.target ).closest( dd.handle, event.currentTarget ).length )
 			return;
 
 		drag.touched = event.type == 'touchstart' ? this : null;
@@ -126,7 +128,7 @@ drag = $special.drag = {
 		dd.pageX = event.pageX;
 		dd.pageY = event.pageY;
 		dd.dragging = null;
-		// handle draginit event... 
+		// handle draginit event...
 		results = drag.hijack( event, "draginit", dd );
 		// early cancel
 		if ( !dd.propagates )
@@ -143,43 +145,43 @@ drag = $special.drag = {
 		// remember how many interactions are propagating
 		dd.propagates = dd.interactions.length;
 		// locate and init the drop targets
-		if ( dd.drop !== false && $special.drop ) 
+		if ( dd.drop !== false && $special.drop )
 			$special.drop.handler( event, dd );
 		// disable text selection
-		drag.textselect( false ); 
+		drag.textselect( false );
 		// bind additional events...
 		if ( drag.touched )
 			$event.add( drag.touched, "touchmove touchend", drag.handler, dd );
-		else 
+		else
 			$event.add( document, "mousemove mouseup", drag.handler, dd );
 		// helps prevent text selection or scrolling
 		if ( !drag.touched || dd.live )
 			return false;
-	},	
-	
+	},
+
 	// returns an interaction object
 	interaction: function( elem, dd ){
 		var offset = $( elem )[ dd.relative ? "position" : "offset" ]() || { top:0, left:0 };
 		return {
-			drag: elem, 
-			callback: new drag.callback(), 
+			drag: elem,
+			callback: new drag.callback(),
 			droppable: [],
 			offset: offset
 		};
 	},
-	
+
 	// handle drag-releatd DOM events
-	handler: function( event ){ 
+	handler: function( event ){
 		// read the data before hijacking anything
-		var dd = event.data;	
+		var dd = event.data;
 		// handle various events
 		switch ( event.type ){
 			// mousemove, check distance, start dragging
-			case !dd.dragging && 'touchmove': 
+			case !dd.dragging && 'touchmove':
 				event.preventDefault();
 			case !dd.dragging && 'mousemove':
 				//  drag tolerance, x² + y² = distance²
-				if ( Math.pow(  event.pageX-dd.pageX, 2 ) + Math.pow(  event.pageY-dd.pageY, 2 ) < Math.pow( dd.distance, 2 ) ) 
+				if ( Math.pow(  event.pageX-dd.pageX, 2 ) + Math.pow(  event.pageY-dd.pageY, 2 ) < Math.pow( dd.distance, 2 ) )
 					break; // distance tolerance not reached
 				event.target = dd.target; // force target from "mousedown" event (fix distance issue)
 				drag.hijack( event, "dragstart", dd ); // trigger "dragstart"
@@ -190,42 +192,42 @@ drag = $special.drag = {
 				event.preventDefault();
 			case 'mousemove':
 				if ( dd.dragging ){
-					// trigger "drag"		
+					// trigger "drag"
 					drag.hijack( event, "drag", dd );
 					if ( dd.propagates ){
 						// manage drop events
 						if ( dd.drop !== false && $special.drop )
-							$special.drop.handler( event, dd ); // "dropstart", "dropend"							
-						break; // "drag" not rejected, stop		
+							$special.drop.handler( event, dd ); // "dropstart", "dropend"
+						break; // "drag" not rejected, stop
 					}
 					event.type = "mouseup"; // helps "drop" handler behave
 				}
 			// mouseup, stop dragging
-			case 'touchend': 
-			case 'mouseup': 
+			case 'touchend':
+			case 'mouseup':
 			default:
 				if ( drag.touched )
 					$event.remove( drag.touched, "touchmove touchend", drag.handler ); // remove touch events
-				else 
-					$event.remove( document, "mousemove mouseup", drag.handler ); // remove page events	
+				else
+					$event.remove( document, "mousemove mouseup", drag.handler ); // remove page events
 				if ( dd.dragging ){
 					if ( dd.drop !== false && $special.drop )
 						$special.drop.handler( event, dd ); // "drop"
-					drag.hijack( event, "dragend", dd ); // trigger "dragend"	
+					drag.hijack( event, "dragend", dd ); // trigger "dragend"
 				}
 				drag.textselect( true ); // enable text selection
 				// if suppressing click events...
 				if ( dd.click === false && dd.dragging )
 					$.data( dd.mousedown, "suppress.click", new Date().getTime() + 5 );
-				dd.dragging = drag.touched = false; // deactivate element	
+				dd.dragging = drag.touched = false; // deactivate element
 				break;
 		}
 	},
-		
+
 	// re-use event object for custom events
 	hijack: function( event, type, dd, x, elem ){
 		// not configured
-		if ( !dd ) 
+		if ( !dd )
 			return;
 		// remember the original event and type
 		var orig = { event:event.originalEvent, type:event.type },
@@ -255,7 +257,7 @@ drag = $special.drag = {
 				callback.target = subject;
 				// force propagtion of the custom event
 				event.isPropagationStopped = function(){ return false; };
-				// handle the event	
+				// handle the event
 				result = subject ? $event.dispatch.call( subject, event, callback ) : null;
 				// stop the drag interaction for this element
 				if ( result === false ){
@@ -270,25 +272,25 @@ drag = $special.drag = {
 				// assign any dropinit elements
 				else if ( type == "dropinit" )
 					ia.droppable.push( drag.element( result ) || subject );
-				// accept a returned proxy element 
+				// accept a returned proxy element
 				if ( type == "dragstart" )
 					ia.proxy = $( drag.element( result ) || ia.drag )[0];
-				// remember this result	
+				// remember this result
 				ia.results.push( result );
 				// forget the event result, for recycling
 				delete event.result;
 				// break on cancelled handler
 				if ( type !== "dropinit" )
 					return result;
-			});	
-			// flatten the results	
-			dd.results[ i ] = drag.flatten( ia.results );	
+			});
+			// flatten the results
+			dd.results[ i ] = drag.flatten( ia.results );
 			// accept a set of valid drop targets
 			if ( type == "dropinit" )
 				ia.droppable = drag.flatten( ia.droppable );
 			// locate drop targets
 			if ( type == "dragstart" && !ia.cancelled )
-				callback.update(); 
+				callback.update();
 		}
 		while ( ++i < len )
 		// restore the original event & type
@@ -297,9 +299,9 @@ drag = $special.drag = {
 		// return all handler results
 		return drag.flatten( dd.results );
 	},
-		
+
 	// extend the callback object with drag/drop properties...
-	properties: function( event, dd, ia ){		
+	properties: function( event, dd, ia ){
 		var obj = ia.callback;
 		// elements
 		obj.drag = ia.drag;
@@ -314,44 +316,44 @@ drag = $special.drag = {
 		obj.originalX = ia.offset.left;
 		obj.originalY = ia.offset.top;
 		// adjusted element position
-		obj.offsetX = obj.originalX + obj.deltaX; 
+		obj.offsetX = obj.originalX + obj.deltaX;
 		obj.offsetY = obj.originalY + obj.deltaY;
 		// assign the drop targets information
 		obj.drop = drag.flatten( ( ia.drop || [] ).slice() );
 		obj.available = drag.flatten( ( ia.droppable || [] ).slice() );
-		return obj;	
+		return obj;
 	},
-	
+
 	// determine is the argument is an element or jquery instance
 	element: function( arg ){
 		if ( arg && ( arg.jquery || arg.nodeType == 1 ) )
 			return arg;
 	},
-	
+
 	// flatten nested jquery objects and arrays into a single dimension array
 	flatten: function( arr ){
 		return $.map( arr, function( member ){
-			return member && member.jquery ? $.makeArray( member ) : 
+			return member && member.jquery ? $.makeArray( member ) :
 				member && member.length ? drag.flatten( member ) : member;
 		});
 	},
-	
+
 	// toggles text selection attributes ON (true) or OFF (false)
-	textselect: function( bool ){ 
+	textselect: function( bool ){
 		$( document )[ bool ? "unbind" : "bind" ]("selectstart", drag.dontstart )
 			.css("MozUserSelect", bool ? "" : "none" );
 		// .attr("unselectable", bool ? "off" : "on" )
-		document.unselectable = bool ? "off" : "on"; 
+		document.unselectable = bool ? "off" : "on";
 	},
-	
+
 	// suppress "selectstart" and "ondragstart" events
-	dontstart: function(){ 
-		return false; 
+	dontstart: function(){
+		return false;
 	},
-	
+
 	// a callback instance contructor
 	callback: function(){}
-	
+
 };
 
 // callback methods
@@ -375,9 +377,9 @@ $event.dispatch = function( event ){
 };
 
 // event fix hooks for touch events...
-var touchHooks = 
-$event.fixHooks.touchstart = 
-$event.fixHooks.touchmove = 
+var touchHooks =
+$event.fixHooks.touchstart =
+$event.fixHooks.touchmove =
 $event.fixHooks.touchend =
 $event.fixHooks.touchcancel = {
 	props: "clientX clientY pageX pageY screenX screenY".split( " " ),
@@ -385,9 +387,9 @@ $event.fixHooks.touchcancel = {
 		if ( orig ){
 			var touched = ( orig.touches && orig.touches[0] )
 				|| ( orig.changedTouches && orig.changedTouches[0] )
-				|| null; 
+				|| null;
 			// iOS webkit: touchstart, touchmove, touchend
-			if ( touched ) 
+			if ( touched )
 				$.each( touchHooks.props, function( i, prop ){
 					event[ prop ] = touched[ prop ];
 				});

--- a/lib/jquery.event.drop-2.2.js
+++ b/lib/jquery.event.drop-2.2.js
@@ -7,9 +7,7 @@
 // Updated: 2012-05-21
 // REQUIRES: jquery 1.7.x, event.drag 2.2
 
-var jQuery = require("jquery");
-
-;(function($){ // secure $ jQuery alias
+var $ = require("jquery");
 
 // Events: drop, dropstart, dropend
 
@@ -300,5 +298,3 @@ drop = $.event.special.drop = {
 
 // share the same special event configuration with related events...
 $special.dropinit = $special.dropstart = $special.dropend = drop;
-
-})(jQuery); // confine scope

--- a/lib/jquery.event.drop-2.2.js
+++ b/lib/jquery.event.drop-2.2.js
@@ -1,11 +1,13 @@
-/*! 
+/*!
  * jquery.event.drop - v 2.2
  * Copyright (c) 2010 Three Dub Media - http://threedubmedia.com
  * Open Source MIT License - http://threedubmedia.com/code/license
  */
-// Created: 2008-06-04 
+// Created: 2008-06-04
 // Updated: 2012-05-21
 // REQUIRES: jquery 1.7.x, event.drag 2.2
+
+var jQuery = require("jquery");
 
 ;(function($){ // secure $ jQuery alias
 
@@ -18,7 +20,7 @@ $.fn.drop = function( str, arg, opts ){
 	// figure out the event handler...
 	fn = $.isFunction( str ) ? str : $.isFunction( arg ) ? arg : null;
 	// fix the event type
-	if ( type.indexOf("drop") !== 0 ) 
+	if ( type.indexOf("drop") !== 0 )
 		type = "drop"+ type;
 	// were options passed
 	opts = ( str == fn ? arg : opts ) || {};
@@ -28,19 +30,19 @@ $.fn.drop = function( str, arg, opts ){
 
 // DROP MANAGEMENT UTILITY
 // returns filtered drop target elements, caches their positions
-$.drop = function( opts ){ 
+$.drop = function( opts ){
 	opts = opts || {};
 	// safely set new options...
-	drop.multi = opts.multi === true ? Infinity : 
+	drop.multi = opts.multi === true ? Infinity :
 		opts.multi === false ? 1 : !isNaN( opts.multi ) ? opts.multi : drop.multi;
 	drop.delay = opts.delay || drop.delay;
-	drop.tolerance = $.isFunction( opts.tolerance ) ? opts.tolerance : 
+	drop.tolerance = $.isFunction( opts.tolerance ) ? opts.tolerance :
 		opts.tolerance === null ? null : drop.tolerance;
 	drop.mode = opts.mode || drop.mode || 'intersect';
 };
 
 // local refs (increase compression)
-var $event = $.event, 
+var $event = $.event,
 $special = $event.special,
 // configure the drop special event
 drop = $.event.special.drop = {
@@ -49,36 +51,36 @@ drop = $.event.special.drop = {
 	multi: 1, // allow multiple drop winners per dragged element
 	delay: 20, // async timeout delay
 	mode: 'overlap', // drop tolerance mode
-		
+
 	// internal cache
-	targets: [], 
-	
+	targets: [],
+
 	// the key name for stored drop data
 	datakey: "dropdata",
-		
+
 	// prevent bubbling for better performance
 	noBubble: true,
-	
+
 	// count bound related events
-	add: function( obj ){ 
+	add: function( obj ){
 		// read the interaction data
 		var data = $.data( this, drop.datakey );
 		// count another realted event
 		data.related += 1;
 	},
-	
+
 	// forget unbound related events
 	remove: function(){
 		$.data( this, drop.datakey ).related -= 1;
 	},
-	
+
 	// configure the interactions
 	setup: function(){
 		// check for related events
-		if ( $.data( this, drop.datakey ) ) 
+		if ( $.data( this, drop.datakey ) )
 			return;
 		// initialize the drop element data
-		var data = { 
+		var data = {
 			related: 0,
 			active: [],
 			anyactive: 0,
@@ -90,29 +92,29 @@ drop = $.event.special.drop = {
 		// store the drop target in internal cache
 		drop.targets.push( this );
 	},
-	
-	// destroy the configure interaction	
-	teardown: function(){ 
+
+	// destroy the configure interaction
+	teardown: function(){
 		var data = $.data( this, drop.datakey ) || {};
 		// check for related events
-		if ( data.related ) 
+		if ( data.related )
 			return;
 		// remove the stored data
 		$.removeData( this, drop.datakey );
 		// reference the targeted element
 		var element = this;
 		// remove from the internal cache
-		drop.targets = $.grep( drop.targets, function( target ){ 
-			return ( target !== element ); 
+		drop.targets = $.grep( drop.targets, function( target ){
+			return ( target !== element );
 		});
 	},
-	
+
 	// shared event handler
-	handler: function( event, dd ){ 
+	handler: function( event, dd ){
 		// local vars
 		var results, $targets;
 		// make sure the right data is available
-		if ( !dd ) 
+		if ( !dd )
 			return;
 		// handle various events
 		switch ( event.type ){
@@ -133,7 +135,7 @@ drop = $.event.special.drop = {
 				// set available target elements
 				dd.droppable = $targets;
 				// activate drop targets for the initial element being dragged
-				$special.drag.hijack( event, "dropinit", dd ); 
+				$special.drag.hijack( event, "dropinit", dd );
 				break;
 			// drag, from $.event.special.drag
 			case 'mousemove': // TOLERATE >>
@@ -141,35 +143,35 @@ drop = $.event.special.drop = {
 				drop.event = event; // store the mousemove event
 				if ( !drop.timer )
 					// monitor drop targets
-					drop.tolerate( dd ); 
+					drop.tolerate( dd );
 				break;
 			// dragend, from $.event.special.drag
 			case 'mouseup': // DROP >> DROPEND >>
 			case 'touchend': // DROP >> DROPEND >>
-				drop.timer = clearTimeout( drop.timer ); // delete timer	
+				drop.timer = clearTimeout( drop.timer ); // delete timer
 				if ( dd.propagates ){
-					$special.drag.hijack( event, "drop", dd ); 
-					$special.drag.hijack( event, "dropend", dd ); 
+					$special.drag.hijack( event, "drop", dd );
+					$special.drag.hijack( event, "dropend", dd );
 				}
 				break;
-				
+
 		}
 	},
-		
+
 	// returns the location positions of an element
-	locate: function( elem, index ){ 
+	locate: function( elem, index ){
 		var data = $.data( elem, drop.datakey ),
-		$elem = $( elem ), 
-		posi = $elem.offset() || {}, 
-		height = $elem.outerHeight(), 
+		$elem = $( elem ),
+		posi = $elem.offset() || {},
+		height = $elem.outerHeight(),
 		width = $elem.outerWidth(),
-		location = { 
-			elem: elem, 
-			width: width, 
+		location = {
+			elem: elem,
+			width: width,
 			height: height,
-			top: posi.top, 
-			left: posi.left, 
-			right: posi.left + width, 
+			top: posi.top,
+			left: posi.left,
+			right: posi.left + width,
 			bottom: posi.top + height
 		};
 		// drag elements might not have dropdata
@@ -180,43 +182,43 @@ drop = $.event.special.drop = {
 		}
 		return location;
 	},
-	
+
 	// test the location positions of an element against another OR an X,Y coord
 	contains: function( target, test ){ // target { location } contains test [x,y] or { location }
 		return ( ( test[0] || test.left ) >= target.left && ( test[0] || test.right ) <= target.right
-			&& ( test[1] || test.top ) >= target.top && ( test[1] || test.bottom ) <= target.bottom ); 
+			&& ( test[1] || test.top ) >= target.top && ( test[1] || test.bottom ) <= target.bottom );
 	},
-	
+
 	// stored tolerance modes
-	modes: { // fn scope: "$.event.special.drop" object 
+	modes: { // fn scope: "$.event.special.drop" object
 		// target with mouse wins, else target with most overlap wins
 		'intersect': function( event, proxy, target ){
 			return this.contains( target, [ event.pageX, event.pageY ] ) ? // check cursor
 				1e9 : this.modes.overlap.apply( this, arguments ); // check overlap
 		},
-		// target with most overlap wins	
+		// target with most overlap wins
 		'overlap': function( event, proxy, target ){
 			// calculate the area of overlap...
 			return Math.max( 0, Math.min( target.bottom, proxy.bottom ) - Math.max( target.top, proxy.top ) )
 				* Math.max( 0, Math.min( target.right, proxy.right ) - Math.max( target.left, proxy.left ) );
 		},
-		// proxy is completely contained within target bounds	
+		// proxy is completely contained within target bounds
 		'fit': function( event, proxy, target ){
 			return this.contains( target, proxy ) ? 1 : 0;
 		},
-		// center of the proxy is contained within target bounds	
+		// center of the proxy is contained within target bounds
 		'middle': function( event, proxy, target ){
 			return this.contains( target, [ proxy.left + proxy.width * .5, proxy.top + proxy.height * .5 ] ) ? 1 : 0;
 		}
-	},	
-	
+	},
+
 	// sort drop target cache by by winner (dsc), then index (asc)
 	sort: function( a, b ){
 		return ( b.winner - a.winner ) || ( a.index - b.index );
 	},
-		
+
 	// async, recursive tolerance execution
-	tolerate: function( dd ){		
+	tolerate: function( dd ){
 		// declare local refs
 		var i, drp, drg, data, arr, len, elem,
 		// interaction iteration variables
@@ -229,30 +231,30 @@ drop = $.event.special.drop = {
 		do if ( ia = dd.interactions[x] ){
 			// check valid interaction
 			if ( !ia )
-				return; 
+				return;
 			// initialize or clear the drop data
 			ia.drop = [];
 			// holds the drop elements
-			arr = []; 
+			arr = [];
 			len = ia.droppable.length;
 			// determine the proxy location, if needed
 			if ( tolerance )
-				drg = drop.locate( ia.proxy ); 
+				drg = drop.locate( ia.proxy );
 			// reset the loop
 			i = 0;
 			// loop each stored drop target
-			do if ( elem = ia.droppable[i] ){ 
+			do if ( elem = ia.droppable[i] ){
 				data = $.data( elem, drop.datakey );
 				drp = data.location;
 				if ( !drp ) continue;
 				// find a winner: tolerance function is defined, call it
-				data.winner = tolerance ? tolerance.call( drop, drop.event, drg, drp ) 
+				data.winner = tolerance ? tolerance.call( drop, drop.event, drg, drp )
 					// mouse position is always the fallback
-					: drop.contains( drp, xy ) ? 1 : 0; 
-				arr.push( data );	
-			} while ( ++i < len ); // loop 
+					: drop.contains( drp, xy ) ? 1 : 0;
+				arr.push( data );
+			} while ( ++i < len ); // loop
 			// sort the drop targets
-			arr.sort( drop.sort );			
+			arr.sort( drop.sort );
 			// reset the loop
 			i = 0;
 			// loop through all of the targets again
@@ -262,7 +264,7 @@ drop = $.event.special.drop = {
 					// new winner... dropstart
 					if ( !data.active[x] && !data.anyactive ){
 						// check to make sure that this is not prevented
-						if ( $special.drag.hijack( drop.event, "dropstart", dd, x, data.elem )[0] !== false ){ 	
+						if ( $special.drag.hijack( drop.event, "dropstart", dd, x, data.elem )[0] !== false ){
 							data.active[x] = 1;
 							data.anyactive += 1;
 						}
@@ -274,29 +276,29 @@ drop = $.event.special.drop = {
 					if ( data.winner )
 						ia.drop.push( data.elem );
 				}
-				// losers... 
+				// losers...
 				else if ( data.active[x] && data.anyactive == 1 ){
 					// former winner... dropend
-					$special.drag.hijack( drop.event, "dropend", dd, x, data.elem ); 
+					$special.drag.hijack( drop.event, "dropend", dd, x, data.elem );
 					data.active[x] = 0;
 					data.anyactive -= 1;
 				}
-			} while ( ++i < len ); // loop 		
+			} while ( ++i < len ); // loop
 		} while ( ++x < end ) // loop
 		// check if the mouse is still moving or is idle
-		if ( drop.last && xy[0] == drop.last.pageX && xy[1] == drop.last.pageY ) 
+		if ( drop.last && xy[0] == drop.last.pageX && xy[1] == drop.last.pageY )
 			delete drop.timer; // idle, don't recurse
 		else  // recurse
-			drop.timer = setTimeout(function(){ 
-				drop.tolerate( dd ); 
+			drop.timer = setTimeout(function(){
+				drop.tolerate( dd );
 			}, drop.delay );
 		// remember event, to compare idleness
-		drop.last = drop.event; 
+		drop.last = drop.event;
 	}
-	
+
 };
 
 // share the same special event configuration with related events...
 $special.dropinit = $special.dropstart = $special.dropend = drop;
 
-})(jQuery); // confine scope	
+})(jQuery); // confine scope

--- a/lib/jquery.simulate.js
+++ b/lib/jquery.simulate.js
@@ -7,9 +7,7 @@
  *
  */
 
-var jQuery = require("jquery");
-
-;(function($) {
+var $ = require("jquery");
 
 $.fn.extend({
 	simulate: function(type, options) {
@@ -149,4 +147,4 @@ $.extend($.simulate, {
 	VK_DOWN: 40
 });
 
-})(jQuery);
+

--- a/lib/jquery.simulate.js
+++ b/lib/jquery.simulate.js
@@ -7,6 +7,8 @@
  *
  */
 
+var jQuery = require("jquery");
+
 ;(function($) {
 
 $.fn.extend({
@@ -109,8 +111,8 @@ $.extend($.simulate.prototype, {
 	},
 
 	drag: function(el) {
-		var self = this, center = this.findCenter(this.target), 
-			options = this.options,	x = Math.floor(center.x), y = Math.floor(center.y), 
+		var self = this, center = this.findCenter(this.target),
+			options = this.options,	x = Math.floor(center.x), y = Math.floor(center.y),
 			dx = options.dx || 0, dy = options.dy || 0, target = this.target;
 		var coord = { clientX: x, clientY: y };
 		this.simulateEvent(target, "mousedown", coord);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "pandell/SlickGrid",
   "author": "Michael Leibman <michael.leibman@gmail.com>",
   "dependencies": {
+    "jquery": "*",
     "node.extend": "^1.1"
   },
   "directories": {

--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -1,89 +1,86 @@
 var Slick = require('../core');
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
+module.exports = AutoTooltips;
 
-  module.exports = AutoTooltips;
+// Register namespace
+$.extend(true, window, {
+  "Slick": {
+    "AutoTooltips": AutoTooltips
+  }
+});
 
-  // Register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "AutoTooltips": AutoTooltips
-    }
-  });
+/**
+ * AutoTooltips plugin to show/hide tooltips when columns are too narrow to fit content.
+ * @constructor
+ * @param {boolean} [options.enableForCells=true]        - Enable tooltip for grid cells
+ * @param {boolean} [options.enableForHeaderCells=false] - Enable tooltip for header cells
+ * @param {number}  [options.maxToolTipLength=null]      - The maximum length for a tooltip
+ */
+function AutoTooltips(options) {
+  var _grid;
+  var _self = this;
+  var _defaults = {
+    enableForCells: true,
+    enableForHeaderCells: false,
+    maxToolTipLength: null
+  };
 
   /**
-   * AutoTooltips plugin to show/hide tooltips when columns are too narrow to fit content.
-   * @constructor
-   * @param {boolean} [options.enableForCells=true]        - Enable tooltip for grid cells
-   * @param {boolean} [options.enableForHeaderCells=false] - Enable tooltip for header cells
-   * @param {number}  [options.maxToolTipLength=null]      - The maximum length for a tooltip
+   * Initialize plugin.
    */
-  function AutoTooltips(options) {
-    var _grid;
-    var _self = this;
-    var _defaults = {
-      enableForCells: true,
-      enableForHeaderCells: false,
-      maxToolTipLength: null
-    };
-
-    /**
-     * Initialize plugin.
-     */
-    function init(grid) {
-      options = $.extend(true, {}, _defaults, options);
-      _grid = grid;
-      if (options.enableForCells) _grid.onMouseEnter.subscribe(handleMouseEnter);
-      if (options.enableForHeaderCells) _grid.onHeaderMouseEnter.subscribe(handleHeaderMouseEnter);
-    }
-
-    /**
-     * Destroy plugin.
-     */
-    function destroy() {
-      if (options.enableForCells) _grid.onMouseEnter.unsubscribe(handleMouseEnter);
-      if (options.enableForHeaderCells) _grid.onHeaderMouseEnter.unsubscribe(handleHeaderMouseEnter);
-    }
-
-    /**
-     * Handle mouse entering grid cell to add/remove tooltip.
-     * @param {jQuery.Event} e - The event
-     */
-    function handleMouseEnter(e) {
-      var cell = _grid.getCellFromEvent(e);
-      if (cell) {
-        var $node = $(_grid.getCellNode(cell.row, cell.cell));
-        var text;
-        if ($node.innerWidth() < $node[0].scrollWidth) {
-          text = $.trim($node.text());
-          if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
-            text = text.substr(0, options.maxToolTipLength - 3) + "...";
-          }
-        } else {
-          text = "";
-        }
-        $node.attr("title", text);
-      }
-    }
-
-    /**
-     * Handle mouse entering header cell to add/remove tooltip.
-     * @param {jQuery.Event} e     - The event
-     * @param {object} args.column - The column definition
-     */
-    function handleHeaderMouseEnter(e, args) {
-      var column = args.column,
-          $node = $(e.target).closest(".slick-header-column");
-      if (!column.toolTip) {
-        $node.attr("title", ($node.innerWidth() < $node[0].scrollWidth) ? column.name : "");
-      }
-    }
-
-    // Public API
-    $.extend(this, {
-      "init": init,
-      "destroy": destroy
-    });
+  function init(grid) {
+    options = $.extend(true, {}, _defaults, options);
+    _grid = grid;
+    if (options.enableForCells) _grid.onMouseEnter.subscribe(handleMouseEnter);
+    if (options.enableForHeaderCells) _grid.onHeaderMouseEnter.subscribe(handleHeaderMouseEnter);
   }
-})(jQuery);
+
+  /**
+   * Destroy plugin.
+   */
+  function destroy() {
+    if (options.enableForCells) _grid.onMouseEnter.unsubscribe(handleMouseEnter);
+    if (options.enableForHeaderCells) _grid.onHeaderMouseEnter.unsubscribe(handleHeaderMouseEnter);
+  }
+
+  /**
+   * Handle mouse entering grid cell to add/remove tooltip.
+   * @param {jQuery.Event} e - The event
+   */
+  function handleMouseEnter(e) {
+    var cell = _grid.getCellFromEvent(e);
+    if (cell) {
+      var $node = $(_grid.getCellNode(cell.row, cell.cell));
+      var text;
+      if ($node.innerWidth() < $node[0].scrollWidth) {
+        text = $.trim($node.text());
+        if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
+          text = text.substr(0, options.maxToolTipLength - 3) + "...";
+        }
+      } else {
+        text = "";
+      }
+      $node.attr("title", text);
+    }
+  }
+
+  /**
+   * Handle mouse entering header cell to add/remove tooltip.
+   * @param {jQuery.Event} e     - The event
+   * @param {object} args.column - The column definition
+   */
+  function handleHeaderMouseEnter(e, args) {
+    var column = args.column,
+        $node = $(e.target).closest(".slick-header-column");
+    if (!column.toolTip) {
+      $node.attr("title", ($node.innerWidth() < $node[0].scrollWidth) ? column.name : "");
+    }
+  }
+
+  // Public API
+  $.extend(this, {
+    "init": init,
+    "destroy": destroy
+  });
+}

--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -1,4 +1,5 @@
 var Slick = require('../core');
+var jQuery = require("jquery");
 
 (function ($) {
 

--- a/plugins/slick.cellcopymanager.js
+++ b/plugins/slick.cellcopymanager.js
@@ -1,92 +1,90 @@
 var Slick = require('../core');
-var jQuery = require("jquery");
-
-(function ($) {
-
-  module.exports = CellCopyManager;
-
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "CellCopyManager": CellCopyManager
-    }
-  });
+var $ = require("jquery");
 
 
-  function CellCopyManager() {
-    var _grid;
-    var _self = this;
-    var _copiedRanges;
+module.exports = CellCopyManager;
 
-    function init(grid) {
-      _grid = grid;
-      _grid.onKeyDown.subscribe(handleKeyDown);
-    }
-
-    function destroy() {
-      _grid.onKeyDown.unsubscribe(handleKeyDown);
-    }
-
-    function handleKeyDown(e, args) {
-      var ranges;
-      if (!_grid.getEditorLock().isActive()) {
-        if (e.which == $.ui.keyCode.ESCAPE) {
-          if (_copiedRanges) {
-            e.preventDefault();
-            clearCopySelection();
-            _self.onCopyCancelled.notify({ranges: _copiedRanges});
-            _copiedRanges = null;
-          }
-        }
-
-        if (e.which == 67 && (e.ctrlKey || e.metaKey)) {
-          ranges = _grid.getSelectionModel().getSelectedRanges();
-          if (ranges.length != 0) {
-            e.preventDefault();
-            _copiedRanges = ranges;
-            markCopySelection(ranges);
-            _self.onCopyCells.notify({ranges: ranges});
-          }
-        }
-
-        if (e.which == 86 && (e.ctrlKey || e.metaKey)) {
-          if (_copiedRanges) {
-            e.preventDefault();
-            clearCopySelection();
-            ranges = _grid.getSelectionModel().getSelectedRanges();
-            _self.onPasteCells.notify({from: _copiedRanges, to: ranges});
-            _copiedRanges = null;
-          }
-        }
-      }
-    }
-
-    function markCopySelection(ranges) {
-      var columns = _grid.getColumns();
-      var hash = {};
-      for (var i = 0; i < ranges.length; i++) {
-        for (var j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
-          hash[j] = {};
-          for (var k = ranges[i].fromCell; k <= ranges[i].toCell; k++) {
-            hash[j][columns[k].id] = "copied";
-          }
-        }
-      }
-      _grid.setCellCssStyles("copy-manager", hash);
-    }
-
-    function clearCopySelection() {
-      _grid.removeCellCssStyles("copy-manager");
-    }
-
-    $.extend(this, {
-      "init": init,
-      "destroy": destroy,
-      "clearCopySelection": clearCopySelection,
-
-      "onCopyCells": new Slick.Event(),
-      "onCopyCancelled": new Slick.Event(),
-      "onPasteCells": new Slick.Event()
-    });
+// register namespace
+$.extend(true, window, {
+  "Slick": {
+    "CellCopyManager": CellCopyManager
   }
-})(jQuery);
+});
+
+
+function CellCopyManager() {
+  var _grid;
+  var _self = this;
+  var _copiedRanges;
+
+  function init(grid) {
+    _grid = grid;
+    _grid.onKeyDown.subscribe(handleKeyDown);
+  }
+
+  function destroy() {
+    _grid.onKeyDown.unsubscribe(handleKeyDown);
+  }
+
+  function handleKeyDown(e, args) {
+    var ranges;
+    if (!_grid.getEditorLock().isActive()) {
+      if (e.which == $.ui.keyCode.ESCAPE) {
+        if (_copiedRanges) {
+          e.preventDefault();
+          clearCopySelection();
+          _self.onCopyCancelled.notify({ranges: _copiedRanges});
+          _copiedRanges = null;
+        }
+      }
+
+      if (e.which == 67 && (e.ctrlKey || e.metaKey)) {
+        ranges = _grid.getSelectionModel().getSelectedRanges();
+        if (ranges.length != 0) {
+          e.preventDefault();
+          _copiedRanges = ranges;
+          markCopySelection(ranges);
+          _self.onCopyCells.notify({ranges: ranges});
+        }
+      }
+
+      if (e.which == 86 && (e.ctrlKey || e.metaKey)) {
+        if (_copiedRanges) {
+          e.preventDefault();
+          clearCopySelection();
+          ranges = _grid.getSelectionModel().getSelectedRanges();
+          _self.onPasteCells.notify({from: _copiedRanges, to: ranges});
+          _copiedRanges = null;
+        }
+      }
+    }
+  }
+
+  function markCopySelection(ranges) {
+    var columns = _grid.getColumns();
+    var hash = {};
+    for (var i = 0; i < ranges.length; i++) {
+      for (var j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
+        hash[j] = {};
+        for (var k = ranges[i].fromCell; k <= ranges[i].toCell; k++) {
+          hash[j][columns[k].id] = "copied";
+        }
+      }
+    }
+    _grid.setCellCssStyles("copy-manager", hash);
+  }
+
+  function clearCopySelection() {
+    _grid.removeCellCssStyles("copy-manager");
+  }
+
+  $.extend(this, {
+    "init": init,
+    "destroy": destroy,
+    "clearCopySelection": clearCopySelection,
+
+    "onCopyCells": new Slick.Event(),
+    "onCopyCancelled": new Slick.Event(),
+    "onPasteCells": new Slick.Event()
+  });
+}

--- a/plugins/slick.cellcopymanager.js
+++ b/plugins/slick.cellcopymanager.js
@@ -1,4 +1,5 @@
 var Slick = require('../core');
+var jQuery = require("jquery");
 
 (function ($) {
 

--- a/plugins/slick.cellrangedecorator.js
+++ b/plugins/slick.cellrangedecorator.js
@@ -1,72 +1,70 @@
 var Slick = require('../core');
-var jQuery = require("jquery");
-
-(function ($) {
-
-  module.exports = CellRangeDecorator;
-
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "CellRangeDecorator": CellRangeDecorator
-    }
-  });
-
-  /***
-   * Displays an overlay on top of a given cell range.
-   *
-   * TODO:
-   * Currently, it blocks mouse events to DOM nodes behind it.
-   * Use FF and WebKit-specific "pointer-events" CSS style, or some kind of event forwarding.
-   * Could also construct the borders separately using 4 individual DIVs.
-   *
-   * @param {Grid} grid
-   * @param {Object} options
-   */
-  function CellRangeDecorator(grid, options) {
-    var _elem;
-    var _defaults = {
-      selectionCssClass: 'slick-range-decorator',
-      selectionCss: {
-        "zIndex": "9999",
-        "border": "2px dashed red"
-      }
-    };
-
-    options = $.extend(true, {}, _defaults, options);
+var $ = require("jquery");
 
 
-    function show(range) {
-      if (!_elem) {
-        _elem = $("<div></div>", {css: options.selectionCss})
-            .addClass(options.selectionCssClass)
-            .css("position", "absolute")
-            .appendTo(grid.getCanvasNode());
-      }
+module.exports = CellRangeDecorator;
 
-      var from = grid.getCellNodeBox(range.fromRow, range.fromCell);
-      var to = grid.getCellNodeBox(range.toRow, range.toCell);
-
-      _elem.css({
-        top: from.top - 1,
-        left: from.left - 1,
-        height: to.bottom - from.top - 2,
-        width: to.right - from.left - 2
-      });
-
-      return _elem;
-    }
-
-    function hide() {
-      if (_elem) {
-        _elem.remove();
-        _elem = null;
-      }
-    }
-
-    $.extend(this, {
-      "show": show,
-      "hide": hide
-    });
+// register namespace
+$.extend(true, window, {
+  "Slick": {
+    "CellRangeDecorator": CellRangeDecorator
   }
-})(jQuery);
+});
+
+/***
+ * Displays an overlay on top of a given cell range.
+ *
+ * TODO:
+ * Currently, it blocks mouse events to DOM nodes behind it.
+ * Use FF and WebKit-specific "pointer-events" CSS style, or some kind of event forwarding.
+ * Could also construct the borders separately using 4 individual DIVs.
+ *
+ * @param {Grid} grid
+ * @param {Object} options
+ */
+function CellRangeDecorator(grid, options) {
+  var _elem;
+  var _defaults = {
+    selectionCssClass: 'slick-range-decorator',
+    selectionCss: {
+      "zIndex": "9999",
+      "border": "2px dashed red"
+    }
+  };
+
+  options = $.extend(true, {}, _defaults, options);
+
+
+  function show(range) {
+    if (!_elem) {
+      _elem = $("<div></div>", {css: options.selectionCss})
+          .addClass(options.selectionCssClass)
+          .css("position", "absolute")
+          .appendTo(grid.getCanvasNode());
+    }
+
+    var from = grid.getCellNodeBox(range.fromRow, range.fromCell);
+    var to = grid.getCellNodeBox(range.toRow, range.toCell);
+
+    _elem.css({
+      top: from.top - 1,
+      left: from.left - 1,
+      height: to.bottom - from.top - 2,
+      width: to.right - from.left - 2
+    });
+
+    return _elem;
+  }
+
+  function hide() {
+    if (_elem) {
+      _elem.remove();
+      _elem = null;
+    }
+  }
+
+  $.extend(this, {
+    "show": show,
+    "hide": hide
+  });
+}

--- a/plugins/slick.cellrangedecorator.js
+++ b/plugins/slick.cellrangedecorator.js
@@ -1,4 +1,5 @@
 var Slick = require('../core');
+var jQuery = require("jquery");
 
 (function ($) {
 

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -1,119 +1,117 @@
 var Slick = require('../core');
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
 
-  module.exports = CellRangeSelector;
+module.exports = CellRangeSelector;
 
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "CellRangeSelector": CellRangeSelector
+// register namespace
+$.extend(true, window, {
+  "Slick": {
+    "CellRangeSelector": CellRangeSelector
+  }
+});
+
+
+function CellRangeSelector(options) {
+  var _grid;
+  var _canvas;
+  var _dragging;
+  var _decorator;
+  var _self = this;
+  var _handler = new Slick.EventHandler();
+  var _defaults = {
+    selectionCss: {
+      "border": "2px dashed blue"
     }
-  });
+  };
 
 
-  function CellRangeSelector(options) {
-    var _grid;
-    var _canvas;
-    var _dragging;
-    var _decorator;
-    var _self = this;
-    var _handler = new Slick.EventHandler();
-    var _defaults = {
-      selectionCss: {
-        "border": "2px dashed blue"
+  function init(grid) {
+    options = $.extend(true, {}, _defaults, options);
+    _decorator = new Slick.CellRangeDecorator(grid, options);
+    _grid = grid;
+    _canvas = _grid.getCanvasNode();
+    _handler
+      .subscribe(_grid.onDragInit, handleDragInit)
+      .subscribe(_grid.onDragStart, handleDragStart)
+      .subscribe(_grid.onDrag, handleDrag)
+      .subscribe(_grid.onDragEnd, handleDragEnd);
+  }
+
+  function destroy() {
+    _handler.unsubscribeAll();
+  }
+
+  function handleDragInit(e, dd) {
+    // prevent the grid from cancelling drag'n'drop by default
+    e.stopImmediatePropagation();
+  }
+
+  function handleDragStart(e, dd) {
+    var cell = _grid.getCellFromEvent(e);
+    if (_self.onBeforeCellRangeSelected.notify(cell) !== false) {
+      if (_grid.canCellBeSelected(cell.row, cell.cell)) {
+        _dragging = true;
+        e.stopImmediatePropagation();
       }
-    };
-
-
-    function init(grid) {
-      options = $.extend(true, {}, _defaults, options);
-      _decorator = new Slick.CellRangeDecorator(grid, options);
-      _grid = grid;
-      _canvas = _grid.getCanvasNode();
-      _handler
-        .subscribe(_grid.onDragInit, handleDragInit)
-        .subscribe(_grid.onDragStart, handleDragStart)
-        .subscribe(_grid.onDrag, handleDrag)
-        .subscribe(_grid.onDragEnd, handleDragEnd);
+    }
+    if (!_dragging) {
+      return;
     }
 
-    function destroy() {
-      _handler.unsubscribeAll();
+    _grid.focus();
+
+    var start = _grid.getCellFromPoint(
+        dd.startX - $(_canvas).offset().left,
+        dd.startY - $(_canvas).offset().top);
+
+    dd.range = {start: start, end: {}};
+
+    return _decorator.show(new Slick.Range(start.row, start.cell));
+  }
+
+  function handleDrag(e, dd) {
+    if (!_dragging) {
+      return;
+    }
+    e.stopImmediatePropagation();
+
+    var end = _grid.getCellFromPoint(
+        e.pageX - $(_canvas).offset().left,
+        e.pageY - $(_canvas).offset().top);
+
+    if (!_grid.canCellBeSelected(end.row, end.cell)) {
+      return;
     }
 
-    function handleDragInit(e, dd) {
-      // prevent the grid from cancelling drag'n'drop by default
-      e.stopImmediatePropagation();
+    dd.range.end = end;
+    _decorator.show(new Slick.Range(dd.range.start.row, dd.range.start.cell, end.row, end.cell));
+  }
+
+  function handleDragEnd(e, dd) {
+    if (!_dragging) {
+      return;
     }
 
-    function handleDragStart(e, dd) {
-      var cell = _grid.getCellFromEvent(e);
-      if (_self.onBeforeCellRangeSelected.notify(cell) !== false) {
-        if (_grid.canCellBeSelected(cell.row, cell.cell)) {
-          _dragging = true;
-          e.stopImmediatePropagation();
-        }
-      }
-      if (!_dragging) {
-        return;
-      }
+    _dragging = false;
+    e.stopImmediatePropagation();
 
-      _grid.focus();
-
-      var start = _grid.getCellFromPoint(
-          dd.startX - $(_canvas).offset().left,
-          dd.startY - $(_canvas).offset().top);
-
-      dd.range = {start: start, end: {}};
-
-      return _decorator.show(new Slick.Range(start.row, start.cell));
-    }
-
-    function handleDrag(e, dd) {
-      if (!_dragging) {
-        return;
-      }
-      e.stopImmediatePropagation();
-
-      var end = _grid.getCellFromPoint(
-          e.pageX - $(_canvas).offset().left,
-          e.pageY - $(_canvas).offset().top);
-
-      if (!_grid.canCellBeSelected(end.row, end.cell)) {
-        return;
-      }
-
-      dd.range.end = end;
-      _decorator.show(new Slick.Range(dd.range.start.row, dd.range.start.cell, end.row, end.cell));
-    }
-
-    function handleDragEnd(e, dd) {
-      if (!_dragging) {
-        return;
-      }
-
-      _dragging = false;
-      e.stopImmediatePropagation();
-
-      _decorator.hide();
-      _self.onCellRangeSelected.notify({
-        range: new Slick.Range(
-            dd.range.start.row,
-            dd.range.start.cell,
-            dd.range.end.row,
-            dd.range.end.cell
-        )
-      });
-    }
-
-    $.extend(this, {
-      "init": init,
-      "destroy": destroy,
-
-      "onBeforeCellRangeSelected": new Slick.Event(),
-      "onCellRangeSelected": new Slick.Event()
+    _decorator.hide();
+    _self.onCellRangeSelected.notify({
+      range: new Slick.Range(
+          dd.range.start.row,
+          dd.range.start.cell,
+          dd.range.end.row,
+          dd.range.end.cell
+      )
     });
   }
-})(jQuery);
+
+  $.extend(this, {
+    "init": init,
+    "destroy": destroy,
+
+    "onBeforeCellRangeSelected": new Slick.Event(),
+    "onCellRangeSelected": new Slick.Event()
+  });
+}

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -1,4 +1,5 @@
 var Slick = require('../core');
+var jQuery = require("jquery");
 
 (function ($) {
 

--- a/plugins/slick.cellselectionmodel.js
+++ b/plugins/slick.cellselectionmodel.js
@@ -1,160 +1,158 @@
 var Slick = require('../core');
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
 
-  module.exports = CellSelectionModel;
+module.exports = CellSelectionModel;
 
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "CellSelectionModel": CellSelectionModel
+// register namespace
+$.extend(true, window, {
+  "Slick": {
+    "CellSelectionModel": CellSelectionModel
+  }
+});
+
+
+function CellSelectionModel(options) {
+  var _grid;
+  var _canvas;
+  var _ranges = [];
+  var _self = this;
+  var _selector = new Slick.CellRangeSelector({
+    "selectionCss": {
+      "border": "2px solid black"
     }
   });
+  var _options;
+  var _defaults = {
+    selectActiveCell: true
+  };
 
 
-  function CellSelectionModel(options) {
-    var _grid;
-    var _canvas;
-    var _ranges = [];
-    var _self = this;
-    var _selector = new Slick.CellRangeSelector({
-      "selectionCss": {
-        "border": "2px solid black"
-      }
-    });
-    var _options;
-    var _defaults = {
-      selectActiveCell: true
-    };
-
-
-    function init(grid) {
-      _options = $.extend(true, {}, _defaults, options);
-      _grid = grid;
-      _canvas = _grid.getCanvasNode();
-      _grid.onActiveCellChanged.subscribe(handleActiveCellChange);
-      _grid.onKeyDown.subscribe(handleKeyDown);
-      grid.registerPlugin(_selector);
-      _selector.onCellRangeSelected.subscribe(handleCellRangeSelected);
-      _selector.onBeforeCellRangeSelected.subscribe(handleBeforeCellRangeSelected);
-    }
-
-    function destroy() {
-      _grid.onActiveCellChanged.unsubscribe(handleActiveCellChange);
-      _grid.onKeyDown.unsubscribe(handleKeyDown);
-      _selector.onCellRangeSelected.unsubscribe(handleCellRangeSelected);
-      _selector.onBeforeCellRangeSelected.unsubscribe(handleBeforeCellRangeSelected);
-      _grid.unregisterPlugin(_selector);
-    }
-
-    function removeInvalidRanges(ranges) {
-      var result = [];
-
-      for (var i = 0; i < ranges.length; i++) {
-        var r = ranges[i];
-        if (_grid.canCellBeSelected(r.fromRow, r.fromCell) && _grid.canCellBeSelected(r.toRow, r.toCell)) {
-          result.push(r);
-        }
-      }
-
-      return result;
-    }
-
-    function setSelectedRanges(ranges) {
-      _ranges = removeInvalidRanges(ranges);
-      _self.onSelectedRangesChanged.notify(_ranges);
-    }
-
-    function getSelectedRanges() {
-      return _ranges;
-    }
-
-    function handleBeforeCellRangeSelected(e, args) {
-      if (_grid.getEditorLock().isActive()) {
-        e.stopPropagation();
-        return false;
-      }
-    }
-
-    function handleCellRangeSelected(e, args) {
-      setSelectedRanges([args.range]);
-    }
-
-    function handleActiveCellChange(e, args) {
-      if (_options.selectActiveCell && args.row != null && args.cell != null) {
-        setSelectedRanges([new Slick.Range(args.row, args.cell)]);
-      }
-    }
-
-    function handleKeyDown(e) {
-      /***
-       * Кey codes
-       * 37 left
-       * 38 up
-       * 39 right
-       * 40 down
-       */
-      var ranges, last;
-      var active = _grid.getActiveCell();
-
-      if ( active && e.shiftKey && !e.ctrlKey && !e.altKey &&
-          (e.which == 37 || e.which == 39 || e.which == 38 || e.which == 40) ) {
-
-        ranges = getSelectedRanges();
-        if (!ranges.length)
-         ranges.push(new Slick.Range(active.row, active.cell));
-
-        // keyboard can work with last range only
-        last = ranges.pop();
-
-        // can't handle selection out of active cell
-        if (!last.contains(active.row, active.cell))
-          last = new Slick.Range(active.row, active.cell);
-
-        var dRow = last.toRow - last.fromRow,
-            dCell = last.toCell - last.fromCell,
-            // walking direction
-            dirRow = active.row == last.fromRow ? 1 : -1,
-            dirCell = active.cell == last.fromCell ? 1 : -1;
-
-        if (e.which == 37) {
-          dCell -= dirCell;
-        } else if (e.which == 39) {
-          dCell += dirCell ;
-        } else if (e.which == 38) {
-          dRow -= dirRow;
-        } else if (e.which == 40) {
-          dRow += dirRow;
-        }
-
-        // define new selection range
-        var new_last = new Slick.Range(active.row, active.cell, active.row + dirRow*dRow, active.cell + dirCell*dCell);
-        if (removeInvalidRanges([new_last]).length) {
-          ranges.push(new_last);
-          var viewRow = dirRow > 0 ? new_last.toRow : new_last.fromRow;
-          var viewCell = dirCell > 0 ? new_last.toCell : new_last.fromCell;
-         _grid.scrollRowIntoView(viewRow);
-         _grid.scrollCellIntoView(viewRow, viewCell);
-        }
-        else
-          ranges.push(last);
-
-        setSelectedRanges(ranges);
-
-        e.preventDefault();
-        e.stopPropagation();
-      }
-    }
-
-    $.extend(this, {
-      "getSelectedRanges": getSelectedRanges,
-      "setSelectedRanges": setSelectedRanges,
-
-      "init": init,
-      "destroy": destroy,
-
-      "onSelectedRangesChanged": new Slick.Event()
-    });
+  function init(grid) {
+    _options = $.extend(true, {}, _defaults, options);
+    _grid = grid;
+    _canvas = _grid.getCanvasNode();
+    _grid.onActiveCellChanged.subscribe(handleActiveCellChange);
+    _grid.onKeyDown.subscribe(handleKeyDown);
+    grid.registerPlugin(_selector);
+    _selector.onCellRangeSelected.subscribe(handleCellRangeSelected);
+    _selector.onBeforeCellRangeSelected.subscribe(handleBeforeCellRangeSelected);
   }
-})(jQuery);
+
+  function destroy() {
+    _grid.onActiveCellChanged.unsubscribe(handleActiveCellChange);
+    _grid.onKeyDown.unsubscribe(handleKeyDown);
+    _selector.onCellRangeSelected.unsubscribe(handleCellRangeSelected);
+    _selector.onBeforeCellRangeSelected.unsubscribe(handleBeforeCellRangeSelected);
+    _grid.unregisterPlugin(_selector);
+  }
+
+  function removeInvalidRanges(ranges) {
+    var result = [];
+
+    for (var i = 0; i < ranges.length; i++) {
+      var r = ranges[i];
+      if (_grid.canCellBeSelected(r.fromRow, r.fromCell) && _grid.canCellBeSelected(r.toRow, r.toCell)) {
+        result.push(r);
+      }
+    }
+
+    return result;
+  }
+
+  function setSelectedRanges(ranges) {
+    _ranges = removeInvalidRanges(ranges);
+    _self.onSelectedRangesChanged.notify(_ranges);
+  }
+
+  function getSelectedRanges() {
+    return _ranges;
+  }
+
+  function handleBeforeCellRangeSelected(e, args) {
+    if (_grid.getEditorLock().isActive()) {
+      e.stopPropagation();
+      return false;
+    }
+  }
+
+  function handleCellRangeSelected(e, args) {
+    setSelectedRanges([args.range]);
+  }
+
+  function handleActiveCellChange(e, args) {
+    if (_options.selectActiveCell && args.row != null && args.cell != null) {
+      setSelectedRanges([new Slick.Range(args.row, args.cell)]);
+    }
+  }
+
+  function handleKeyDown(e) {
+    /***
+     * Кey codes
+     * 37 left
+     * 38 up
+     * 39 right
+     * 40 down
+     */
+    var ranges, last;
+    var active = _grid.getActiveCell();
+
+    if ( active && e.shiftKey && !e.ctrlKey && !e.altKey &&
+        (e.which == 37 || e.which == 39 || e.which == 38 || e.which == 40) ) {
+
+      ranges = getSelectedRanges();
+      if (!ranges.length)
+       ranges.push(new Slick.Range(active.row, active.cell));
+
+      // keyboard can work with last range only
+      last = ranges.pop();
+
+      // can't handle selection out of active cell
+      if (!last.contains(active.row, active.cell))
+        last = new Slick.Range(active.row, active.cell);
+
+      var dRow = last.toRow - last.fromRow,
+          dCell = last.toCell - last.fromCell,
+          // walking direction
+          dirRow = active.row == last.fromRow ? 1 : -1,
+          dirCell = active.cell == last.fromCell ? 1 : -1;
+
+      if (e.which == 37) {
+        dCell -= dirCell;
+      } else if (e.which == 39) {
+        dCell += dirCell ;
+      } else if (e.which == 38) {
+        dRow -= dirRow;
+      } else if (e.which == 40) {
+        dRow += dirRow;
+      }
+
+      // define new selection range
+      var new_last = new Slick.Range(active.row, active.cell, active.row + dirRow*dRow, active.cell + dirCell*dCell);
+      if (removeInvalidRanges([new_last]).length) {
+        ranges.push(new_last);
+        var viewRow = dirRow > 0 ? new_last.toRow : new_last.fromRow;
+        var viewCell = dirCell > 0 ? new_last.toCell : new_last.fromCell;
+       _grid.scrollRowIntoView(viewRow);
+       _grid.scrollCellIntoView(viewRow, viewCell);
+      }
+      else
+        ranges.push(last);
+
+      setSelectedRanges(ranges);
+
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }
+
+  $.extend(this, {
+    "getSelectedRanges": getSelectedRanges,
+    "setSelectedRanges": setSelectedRanges,
+
+    "init": init,
+    "destroy": destroy,
+
+    "onSelectedRangesChanged": new Slick.Event()
+  });
+}

--- a/plugins/slick.cellselectionmodel.js
+++ b/plugins/slick.cellselectionmodel.js
@@ -1,4 +1,5 @@
 var Slick = require('../core');
+var jQuery = require("jquery");
 
 (function ($) {
 

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -1,159 +1,157 @@
 var Slick = require('../core');
-var jQuery = require("jquery");
-
-(function ($) {
-
-  module.exports = CheckboxSelectColumn;
-
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "CheckboxSelectColumn": CheckboxSelectColumn
-    }
-  });
+var $ = require("jquery");
 
 
-  function CheckboxSelectColumn(options) {
-    var _grid;
-    var _self = this;
-    var _handler = new Slick.EventHandler();
-    var _selectedRowsLookup = {};
-    var _defaults = {
-      columnId: "_checkbox_selector",
-      cssClass: null,
-      toolTip: "Select/Deselect All",
-      width: 30
-    };
+module.exports = CheckboxSelectColumn;
 
-    var _options = $.extend(true, {}, _defaults, options);
-
-    function init(grid) {
-      _grid = grid;
-      _handler
-        .subscribe(_grid.onSelectedRowsChanged, handleSelectedRowsChanged)
-        .subscribe(_grid.onClick, handleClick)
-        .subscribe(_grid.onHeaderClick, handleHeaderClick)
-        .subscribe(_grid.onKeyDown, handleKeyDown);
-    }
-
-    function destroy() {
-      _handler.unsubscribeAll();
-    }
-
-    function handleSelectedRowsChanged(e, args) {
-      var selectedRows = _grid.getSelectedRows();
-      var lookup = {}, row, i;
-      for (i = 0; i < selectedRows.length; i++) {
-        row = selectedRows[i];
-        lookup[row] = true;
-        if (lookup[row] !== _selectedRowsLookup[row]) {
-          _grid.invalidateRow(row);
-          delete _selectedRowsLookup[row];
-        }
-      }
-      for (i in _selectedRowsLookup) {
-        _grid.invalidateRow(i);
-      }
-      _selectedRowsLookup = lookup;
-      _grid.render();
-
-      if (selectedRows.length && selectedRows.length == _grid.getDataLength()) {
-        _grid.updateColumnHeader(_options.columnId, "<input type='checkbox' checked='checked'>", _options.toolTip);
-      } else {
-        _grid.updateColumnHeader(_options.columnId, "<input type='checkbox'>", _options.toolTip);
-      }
-    }
-
-    function handleKeyDown(e, args) {
-      if (e.which == 32) {
-        if (_grid.getColumns()[args.cell].id === _options.columnId) {
-          // if editing, try to commit
-          if (!_grid.getEditorLock().isActive() || _grid.getEditorLock().commitCurrentEdit()) {
-            toggleRowSelection(args.row);
-          }
-          e.preventDefault();
-          e.stopImmediatePropagation();
-        }
-      }
-    }
-
-    function handleClick(e, args) {
-      // clicking on a row select checkbox
-      if (_grid.getColumns()[args.cell].id === _options.columnId && $(e.target).is(":checkbox")) {
-        // if editing, try to commit
-        if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          return;
-        }
-
-        toggleRowSelection(args.row);
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-      }
-    }
-
-    function toggleRowSelection(row) {
-      if (_selectedRowsLookup[row]) {
-        _grid.setSelectedRows($.grep(_grid.getSelectedRows(), function (n) {
-          return n != row
-        }));
-      } else {
-        _grid.setSelectedRows(_grid.getSelectedRows().concat(row));
-      }
-    }
-
-    function handleHeaderClick(e, args) {
-      if (args.column.id == _options.columnId && $(e.target).is(":checkbox")) {
-        // if editing, try to commit
-        if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          return;
-        }
-
-        if ($(e.target).is(":checked")) {
-          var rows = [];
-          for (var i = 0; i < _grid.getDataLength(); i++) {
-            rows.push(i);
-          }
-          _grid.setSelectedRows(rows);
-        } else {
-          _grid.setSelectedRows([]);
-        }
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-      }
-    }
-
-    function getColumnDefinition() {
-      return {
-        id: _options.columnId,
-        name: "<input type='checkbox'>",
-        toolTip: _options.toolTip,
-        field: "sel",
-        width: _options.width,
-        resizable: false,
-        sortable: false,
-        cssClass: _options.cssClass,
-        formatter: checkboxSelectionFormatter
-      };
-    }
-
-    function checkboxSelectionFormatter(row, cell, value, columnDef, dataContext) {
-      if (dataContext) {
-        return _selectedRowsLookup[row]
-            ? "<input type='checkbox' checked='checked'>"
-            : "<input type='checkbox'>";
-      }
-      return null;
-    }
-
-    $.extend(this, {
-      "init": init,
-      "destroy": destroy,
-
-      "getColumnDefinition": getColumnDefinition
-    });
+// register namespace
+$.extend(true, window, {
+  "Slick": {
+    "CheckboxSelectColumn": CheckboxSelectColumn
   }
-})(jQuery);
+});
+
+
+function CheckboxSelectColumn(options) {
+  var _grid;
+  var _self = this;
+  var _handler = new Slick.EventHandler();
+  var _selectedRowsLookup = {};
+  var _defaults = {
+    columnId: "_checkbox_selector",
+    cssClass: null,
+    toolTip: "Select/Deselect All",
+    width: 30
+  };
+
+  var _options = $.extend(true, {}, _defaults, options);
+
+  function init(grid) {
+    _grid = grid;
+    _handler
+      .subscribe(_grid.onSelectedRowsChanged, handleSelectedRowsChanged)
+      .subscribe(_grid.onClick, handleClick)
+      .subscribe(_grid.onHeaderClick, handleHeaderClick)
+      .subscribe(_grid.onKeyDown, handleKeyDown);
+  }
+
+  function destroy() {
+    _handler.unsubscribeAll();
+  }
+
+  function handleSelectedRowsChanged(e, args) {
+    var selectedRows = _grid.getSelectedRows();
+    var lookup = {}, row, i;
+    for (i = 0; i < selectedRows.length; i++) {
+      row = selectedRows[i];
+      lookup[row] = true;
+      if (lookup[row] !== _selectedRowsLookup[row]) {
+        _grid.invalidateRow(row);
+        delete _selectedRowsLookup[row];
+      }
+    }
+    for (i in _selectedRowsLookup) {
+      _grid.invalidateRow(i);
+    }
+    _selectedRowsLookup = lookup;
+    _grid.render();
+
+    if (selectedRows.length && selectedRows.length == _grid.getDataLength()) {
+      _grid.updateColumnHeader(_options.columnId, "<input type='checkbox' checked='checked'>", _options.toolTip);
+    } else {
+      _grid.updateColumnHeader(_options.columnId, "<input type='checkbox'>", _options.toolTip);
+    }
+  }
+
+  function handleKeyDown(e, args) {
+    if (e.which == 32) {
+      if (_grid.getColumns()[args.cell].id === _options.columnId) {
+        // if editing, try to commit
+        if (!_grid.getEditorLock().isActive() || _grid.getEditorLock().commitCurrentEdit()) {
+          toggleRowSelection(args.row);
+        }
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      }
+    }
+  }
+
+  function handleClick(e, args) {
+    // clicking on a row select checkbox
+    if (_grid.getColumns()[args.cell].id === _options.columnId && $(e.target).is(":checkbox")) {
+      // if editing, try to commit
+      if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        return;
+      }
+
+      toggleRowSelection(args.row);
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+    }
+  }
+
+  function toggleRowSelection(row) {
+    if (_selectedRowsLookup[row]) {
+      _grid.setSelectedRows($.grep(_grid.getSelectedRows(), function (n) {
+        return n != row
+      }));
+    } else {
+      _grid.setSelectedRows(_grid.getSelectedRows().concat(row));
+    }
+  }
+
+  function handleHeaderClick(e, args) {
+    if (args.column.id == _options.columnId && $(e.target).is(":checkbox")) {
+      // if editing, try to commit
+      if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        return;
+      }
+
+      if ($(e.target).is(":checked")) {
+        var rows = [];
+        for (var i = 0; i < _grid.getDataLength(); i++) {
+          rows.push(i);
+        }
+        _grid.setSelectedRows(rows);
+      } else {
+        _grid.setSelectedRows([]);
+      }
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+    }
+  }
+
+  function getColumnDefinition() {
+    return {
+      id: _options.columnId,
+      name: "<input type='checkbox'>",
+      toolTip: _options.toolTip,
+      field: "sel",
+      width: _options.width,
+      resizable: false,
+      sortable: false,
+      cssClass: _options.cssClass,
+      formatter: checkboxSelectionFormatter
+    };
+  }
+
+  function checkboxSelectionFormatter(row, cell, value, columnDef, dataContext) {
+    if (dataContext) {
+      return _selectedRowsLookup[row]
+          ? "<input type='checkbox' checked='checked'>"
+          : "<input type='checkbox'>";
+    }
+    return null;
+  }
+
+  $.extend(this, {
+    "init": init,
+    "destroy": destroy,
+
+    "getColumnDefinition": getColumnDefinition
+  });
+}

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -1,4 +1,5 @@
 var Slick = require('../core');
+var jQuery = require("jquery");
 
 (function ($) {
 

--- a/plugins/slick.headerbuttons.js
+++ b/plugins/slick.headerbuttons.js
@@ -1,183 +1,180 @@
 var Slick = require('../core');
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
+module.exports = HeaderButtons;
 
-  module.exports = HeaderButtons;
-
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Plugins": {
-        "HeaderButtons": HeaderButtons
-      }
+// register namespace
+$.extend(true, window, {
+  "Slick": {
+    "Plugins": {
+      "HeaderButtons": HeaderButtons
     }
-  });
-
-
-  /***
-   * A plugin to add custom buttons to column headers.
-   *
-   * USAGE:
-   *
-   * Add the plugin .js & .css files and register it with the grid.
-   *
-   * To specify a custom button in a column header, extend the column definition like so:
-   *
-   *   var columns = [
-   *     {
-   *       id: 'myColumn',
-   *       name: 'My column',
-   *
-   *       // This is the relevant part
-   *       header: {
-   *          buttons: [
-   *              {
-   *                // button options
-   *              },
-   *              {
-   *                // button options
-   *              }
-   *          ]
-   *       }
-   *     }
-   *   ];
-   *
-   * Available button options:
-   *    cssClass:     CSS class to add to the button.
-   *    image:        Relative button image path.
-   *    tooltip:      Button tooltip.
-   *    showOnHover:  Only show the button on hover.
-   *    handler:      Button click handler.
-   *    command:      A command identifier to be passed to the onCommand event handlers.
-   *
-   * The plugin exposes the following events:
-   *    onCommand:    Fired on button click for buttons with 'command' specified.
-   *        Event args:
-   *            grid:     Reference to the grid.
-   *            column:   Column definition.
-   *            command:  Button command identified.
-   *            button:   Button options.  Note that you can change the button options in your
-   *                      event handler, and the column header will be automatically updated to
-   *                      reflect them.  This is useful if you want to implement something like a
-   *                      toggle button.
-   *
-   *
-   * @param options {Object} Options:
-   *    buttonCssClass:   a CSS class to use for buttons (default 'slick-header-button')
-   * @class Slick.Plugins.HeaderButtons
-   * @constructor
-   */
-  function HeaderButtons(options) {
-    var _grid;
-    var _self = this;
-    var _handler = new Slick.EventHandler();
-    var _defaults = {
-      buttonCssClass: "slick-header-button"
-    };
-
-
-    function init(grid) {
-      options = $.extend(true, {}, _defaults, options);
-      _grid = grid;
-      _handler
-        .subscribe(_grid.onHeaderCellRendered, handleHeaderCellRendered)
-        .subscribe(_grid.onBeforeHeaderCellDestroy, handleBeforeHeaderCellDestroy);
-
-      // Force the grid to re-render the header now that the events are hooked up.
-      _grid.setColumns(_grid.getColumns());
-    }
-
-
-    function destroy() {
-      _handler.unsubscribeAll();
-    }
-
-
-    function handleHeaderCellRendered(e, args) {
-      var column = args.column;
-
-      if (column.header && column.header.buttons) {
-        // Append buttons in reverse order since they are floated to the right.
-        var i = column.header.buttons.length;
-        while (i--) {
-          var button = column.header.buttons[i];
-          var btn = $("<div></div>")
-            .addClass(options.buttonCssClass)
-            .data("column", column)
-            .data("button", button);
-
-          if (button.showOnHover) {
-            btn.addClass("slick-header-button-hidden");
-          }
-
-          if (button.image) {
-            btn.css("backgroundImage", "url(" + button.image + ")");
-          }
-
-          if (button.cssClass) {
-            btn.addClass(button.cssClass);
-          }
-
-          if (button.tooltip) {
-            btn.attr("title", button.tooltip);
-          }
-
-          if (button.command) {
-            btn.data("command", button.command);
-          }
-
-          if (button.handler) {
-            btn.bind("click", button.handler);
-          }
-
-          btn
-            .bind("click", handleButtonClick)
-            .appendTo(args.node);
-        }
-      }
-    }
-
-
-    function handleBeforeHeaderCellDestroy(e, args) {
-      var column = args.column;
-
-      if (column.header && column.header.buttons) {
-        // Removing buttons via jQuery will also clean up any event handlers and data.
-        // NOTE: If you attach event handlers directly or using a different framework,
-        //       you must also clean them up here to avoid memory leaks.
-        $(args.node).find("." + options.buttonCssClass).remove();
-      }
-    }
-
-
-    function handleButtonClick(e) {
-      var command = $(this).data("command");
-      var columnDef = $(this).data("column");
-      var button = $(this).data("button");
-
-      if (command != null) {
-        _self.onCommand.notify({
-            "grid": _grid,
-            "column": columnDef,
-            "command": command,
-            "button": button
-          }, e, _self);
-
-        // Update the header in case the user updated the button definition in the handler.
-        _grid.updateColumnHeader(columnDef.id);
-      }
-
-      // Stop propagation so that it doesn't register as a header click event.
-      e.preventDefault();
-      e.stopPropagation();
-    }
-
-    $.extend(this, {
-      "init": init,
-      "destroy": destroy,
-
-      "onCommand": new Slick.Event()
-    });
   }
-})(jQuery);
+});
+
+
+/***
+ * A plugin to add custom buttons to column headers.
+ *
+ * USAGE:
+ *
+ * Add the plugin .js & .css files and register it with the grid.
+ *
+ * To specify a custom button in a column header, extend the column definition like so:
+ *
+ *   var columns = [
+ *     {
+ *       id: 'myColumn',
+ *       name: 'My column',
+ *
+ *       // This is the relevant part
+ *       header: {
+ *          buttons: [
+ *              {
+ *                // button options
+ *              },
+ *              {
+ *                // button options
+ *              }
+ *          ]
+ *       }
+ *     }
+ *   ];
+ *
+ * Available button options:
+ *    cssClass:     CSS class to add to the button.
+ *    image:        Relative button image path.
+ *    tooltip:      Button tooltip.
+ *    showOnHover:  Only show the button on hover.
+ *    handler:      Button click handler.
+ *    command:      A command identifier to be passed to the onCommand event handlers.
+ *
+ * The plugin exposes the following events:
+ *    onCommand:    Fired on button click for buttons with 'command' specified.
+ *        Event args:
+ *            grid:     Reference to the grid.
+ *            column:   Column definition.
+ *            command:  Button command identified.
+ *            button:   Button options.  Note that you can change the button options in your
+ *                      event handler, and the column header will be automatically updated to
+ *                      reflect them.  This is useful if you want to implement something like a
+ *                      toggle button.
+ *
+ *
+ * @param options {Object} Options:
+ *    buttonCssClass:   a CSS class to use for buttons (default 'slick-header-button')
+ * @class Slick.Plugins.HeaderButtons
+ * @constructor
+ */
+function HeaderButtons(options) {
+  var _grid;
+  var _self = this;
+  var _handler = new Slick.EventHandler();
+  var _defaults = {
+    buttonCssClass: "slick-header-button"
+  };
+
+
+  function init(grid) {
+    options = $.extend(true, {}, _defaults, options);
+    _grid = grid;
+    _handler
+      .subscribe(_grid.onHeaderCellRendered, handleHeaderCellRendered)
+      .subscribe(_grid.onBeforeHeaderCellDestroy, handleBeforeHeaderCellDestroy);
+
+    // Force the grid to re-render the header now that the events are hooked up.
+    _grid.setColumns(_grid.getColumns());
+  }
+
+
+  function destroy() {
+    _handler.unsubscribeAll();
+  }
+
+
+  function handleHeaderCellRendered(e, args) {
+    var column = args.column;
+
+    if (column.header && column.header.buttons) {
+      // Append buttons in reverse order since they are floated to the right.
+      var i = column.header.buttons.length;
+      while (i--) {
+        var button = column.header.buttons[i];
+        var btn = $("<div></div>")
+          .addClass(options.buttonCssClass)
+          .data("column", column)
+          .data("button", button);
+
+        if (button.showOnHover) {
+          btn.addClass("slick-header-button-hidden");
+        }
+
+        if (button.image) {
+          btn.css("backgroundImage", "url(" + button.image + ")");
+        }
+
+        if (button.cssClass) {
+          btn.addClass(button.cssClass);
+        }
+
+        if (button.tooltip) {
+          btn.attr("title", button.tooltip);
+        }
+
+        if (button.command) {
+          btn.data("command", button.command);
+        }
+
+        if (button.handler) {
+          btn.bind("click", button.handler);
+        }
+
+        btn
+          .bind("click", handleButtonClick)
+          .appendTo(args.node);
+      }
+    }
+  }
+
+
+  function handleBeforeHeaderCellDestroy(e, args) {
+    var column = args.column;
+
+    if (column.header && column.header.buttons) {
+      // Removing buttons via jQuery will also clean up any event handlers and data.
+      // NOTE: If you attach event handlers directly or using a different framework,
+      //       you must also clean them up here to avoid memory leaks.
+      $(args.node).find("." + options.buttonCssClass).remove();
+    }
+  }
+
+
+  function handleButtonClick(e) {
+    var command = $(this).data("command");
+    var columnDef = $(this).data("column");
+    var button = $(this).data("button");
+
+    if (command != null) {
+      _self.onCommand.notify({
+          "grid": _grid,
+          "column": columnDef,
+          "command": command,
+          "button": button
+        }, e, _self);
+
+      // Update the header in case the user updated the button definition in the handler.
+      _grid.updateColumnHeader(columnDef.id);
+    }
+
+    // Stop propagation so that it doesn't register as a header click event.
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  $.extend(this, {
+    "init": init,
+    "destroy": destroy,
+
+    "onCommand": new Slick.Event()
+  });
+}

--- a/plugins/slick.headerbuttons.js
+++ b/plugins/slick.headerbuttons.js
@@ -1,4 +1,5 @@
 var Slick = require('../core');
+var jQuery = require("jquery");
 
 (function ($) {
 

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -1,4 +1,5 @@
 var Slick = require('../core');
+var jQuery = require("jquery");
 
 (function ($) {
 

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -1,281 +1,279 @@
 var Slick = require('../core');
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
 
-  module.exports = HeaderMenu;
+module.exports = HeaderMenu;
 
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Plugins": {
-        "HeaderMenu": HeaderMenu
-      }
+// register namespace
+$.extend(true, window, {
+  "Slick": {
+    "Plugins": {
+      "HeaderMenu": HeaderMenu
     }
-  });
+  }
+});
 
 
-  /***
-   * A plugin to add drop-down menus to column headers.
-   *
-   * USAGE:
-   *
-   * Add the plugin .js & .css files and register it with the grid.
-   *
-   * To specify a menu in a column header, extend the column definition like so:
-   *
-   *   var columns = [
-   *     {
-   *       id: 'myColumn',
-   *       name: 'My column',
-   *
-   *       // This is the relevant part
-   *       header: {
-   *          menu: {
-   *              items: [
-   *                {
-   *                  // menu item options
-   *                },
-   *                {
-   *                  // menu item options
-   *                }
-   *              ]
-   *          }
-   *       }
-   *     }
-   *   ];
-   *
-   *
-   * Available menu options:
-   *    tooltip:      Menu button tooltip.
-   *
-   *
-   * Available menu item options:
-   *    title:        Menu item text.
-   *    disabled:     Whether the item is disabled.
-   *    tooltip:      Item tooltip.
-   *    command:      A command identifier to be passed to the onCommand event handlers.
-   *    iconCssClass: A CSS class to be added to the menu item icon.
-   *    iconImage:    A url to the icon image.
-   *
-   *
-   * The plugin exposes the following events:
-   *    onBeforeMenuShow:   Fired before the menu is shown.  You can customize the menu or dismiss it by returning false.
-   *        Event args:
-   *            grid:     Reference to the grid.
-   *            column:   Column definition.
-   *            menu:     Menu options.  Note that you can change the menu items here.
-   *
-   *    onCommand:    Fired on menu item click for buttons with 'command' specified.
-   *        Event args:
-   *            grid:     Reference to the grid.
-   *            column:   Column definition.
-   *            command:  Button command identified.
-   *            button:   Button options.  Note that you can change the button options in your
-   *                      event handler, and the column header will be automatically updated to
-   *                      reflect them.  This is useful if you want to implement something like a
-   *                      toggle button.
-   *
-   *
-   * @param options {Object} Options:
-   *    buttonCssClass:   an extra CSS class to add to the menu button
-   *    buttonImage:      a url to the menu button image (default '../images/down.gif')
-   * @class Slick.Plugins.HeaderButtons
-   * @constructor
-   */
-  function HeaderMenu(options) {
-    var _grid;
-    var _self = this;
-    var _handler = new Slick.EventHandler();
-    var _defaults = {
-      buttonCssClass: null,
-      buttonImage: null
-    };
-    var $menu;
-    var $activeHeaderColumn;
+/***
+ * A plugin to add drop-down menus to column headers.
+ *
+ * USAGE:
+ *
+ * Add the plugin .js & .css files and register it with the grid.
+ *
+ * To specify a menu in a column header, extend the column definition like so:
+ *
+ *   var columns = [
+ *     {
+ *       id: 'myColumn',
+ *       name: 'My column',
+ *
+ *       // This is the relevant part
+ *       header: {
+ *          menu: {
+ *              items: [
+ *                {
+ *                  // menu item options
+ *                },
+ *                {
+ *                  // menu item options
+ *                }
+ *              ]
+ *          }
+ *       }
+ *     }
+ *   ];
+ *
+ *
+ * Available menu options:
+ *    tooltip:      Menu button tooltip.
+ *
+ *
+ * Available menu item options:
+ *    title:        Menu item text.
+ *    disabled:     Whether the item is disabled.
+ *    tooltip:      Item tooltip.
+ *    command:      A command identifier to be passed to the onCommand event handlers.
+ *    iconCssClass: A CSS class to be added to the menu item icon.
+ *    iconImage:    A url to the icon image.
+ *
+ *
+ * The plugin exposes the following events:
+ *    onBeforeMenuShow:   Fired before the menu is shown.  You can customize the menu or dismiss it by returning false.
+ *        Event args:
+ *            grid:     Reference to the grid.
+ *            column:   Column definition.
+ *            menu:     Menu options.  Note that you can change the menu items here.
+ *
+ *    onCommand:    Fired on menu item click for buttons with 'command' specified.
+ *        Event args:
+ *            grid:     Reference to the grid.
+ *            column:   Column definition.
+ *            command:  Button command identified.
+ *            button:   Button options.  Note that you can change the button options in your
+ *                      event handler, and the column header will be automatically updated to
+ *                      reflect them.  This is useful if you want to implement something like a
+ *                      toggle button.
+ *
+ *
+ * @param options {Object} Options:
+ *    buttonCssClass:   an extra CSS class to add to the menu button
+ *    buttonImage:      a url to the menu button image (default '../images/down.gif')
+ * @class Slick.Plugins.HeaderButtons
+ * @constructor
+ */
+function HeaderMenu(options) {
+  var _grid;
+  var _self = this;
+  var _handler = new Slick.EventHandler();
+  var _defaults = {
+    buttonCssClass: null,
+    buttonImage: null
+  };
+  var $menu;
+  var $activeHeaderColumn;
 
 
-    function init(grid) {
-      options = $.extend(true, {}, _defaults, options);
-      _grid = grid;
-      _handler
-        .subscribe(_grid.onHeaderCellRendered, handleHeaderCellRendered)
-        .subscribe(_grid.onBeforeHeaderCellDestroy, handleBeforeHeaderCellDestroy);
+  function init(grid) {
+    options = $.extend(true, {}, _defaults, options);
+    _grid = grid;
+    _handler
+      .subscribe(_grid.onHeaderCellRendered, handleHeaderCellRendered)
+      .subscribe(_grid.onBeforeHeaderCellDestroy, handleBeforeHeaderCellDestroy);
 
-      // Force the grid to re-render the header now that the events are hooked up.
-      _grid.setColumns(_grid.getColumns());
+    // Force the grid to re-render the header now that the events are hooked up.
+    _grid.setColumns(_grid.getColumns());
 
-      // Hide the menu on outside click.
-      $(document.body).bind("mousedown", handleBodyMouseDown);
+    // Hide the menu on outside click.
+    $(document.body).bind("mousedown", handleBodyMouseDown);
+  }
+
+
+  function destroy() {
+    _handler.unsubscribeAll();
+    $(document.body).unbind("mousedown", handleBodyMouseDown);
+  }
+
+
+  function handleBodyMouseDown(e) {
+    if ($menu && $menu[0] != e.target && !$.contains($menu[0], e.target)) {
+      hideMenu();
     }
+  }
 
 
-    function destroy() {
-      _handler.unsubscribeAll();
-      $(document.body).unbind("mousedown", handleBodyMouseDown);
-    }
-
-
-    function handleBodyMouseDown(e) {
-      if ($menu && $menu[0] != e.target && !$.contains($menu[0], e.target)) {
-        hideMenu();
-      }
-    }
-
-
-    function hideMenu() {
-      if ($menu) {
-        $menu.remove();
-        $menu = null;
-        $activeHeaderColumn
-          .removeClass("slick-header-column-active");
-      }
-    }
-
-    function handleHeaderCellRendered(e, args) {
-      var column = args.column;
-      var menu = column.header && column.header.menu;
-
-      if (menu) {
-        var $el = $("<div></div>")
-          .addClass("slick-header-menubutton")
-          .data("column", column)
-          .data("menu", menu);
-
-        if (options.buttonCssClass) {
-          $el.addClass(options.buttonCssClass);
-        }
-
-        if (options.buttonImage) {
-          $el.css("background-image", "url(" + options.buttonImage + ")");
-        }
-
-        if (menu.tooltip) {
-          $el.attr("title", menu.tooltip);
-        }
-
-        $el
-          .bind("click", showMenu)
-          .appendTo(args.node);
-      }
-    }
-
-
-    function handleBeforeHeaderCellDestroy(e, args) {
-      var column = args.column;
-
-      if (column.header && column.header.menu) {
-        $(args.node).find(".slick-header-menubutton").remove();
-      }
-    }
-
-
-    function showMenu(e) {
-      var $menuButton = $(this);
-      var menu = $menuButton.data("menu");
-      var columnDef = $menuButton.data("column");
-
-      // Let the user modify the menu or cancel altogether,
-      // or provide alternative menu implementation.
-      if (_self.onBeforeMenuShow.notify({
-          "grid": _grid,
-          "column": columnDef,
-          "menu": menu
-        }, e, _self) == false) {
-        return;
-      }
-
-
-      if (!$menu) {
-        $menu = $("<div class='slick-header-menu'></div>")
-          .appendTo(_grid.getContainerNode());
-      }
-      $menu.empty();
-
-
-      // Construct the menu items.
-      for (var i = 0; i < menu.items.length; i++) {
-        var item = menu.items[i];
-
-        var $li = $("<div class='slick-header-menuitem'></div>")
-          .data("command", item.command || '')
-          .data("column", columnDef)
-          .data("item", item)
-          .bind("click", handleMenuItemClick)
-          .appendTo($menu);
-
-        if (item.disabled) {
-          $li.addClass("slick-header-menuitem-disabled");
-        }
-
-        if (item.tooltip) {
-          $li.attr("title", item.tooltip);
-        }
-
-        var $icon = $("<div class='slick-header-menuicon'></div>")
-          .appendTo($li);
-
-        if (item.iconCssClass) {
-          $icon.addClass(item.iconCssClass);
-        }
-
-        if (item.iconImage) {
-          $icon.css("background-image", "url(" + item.iconImage + ")");
-        }
-
-        $("<span class='slick-header-menucontent'></span>")
-          .text(item.title)
-          .appendTo($li);
-      }
-
-
-      // Position the menu.
-      $menu
-        .offset({ top: $(this).offset().top + $(this).height(), left: $(this).offset().left });
-
-
-      // Mark the header as active to keep the highlighting.
-      $activeHeaderColumn = $menuButton.closest(".slick-header-column");
+  function hideMenu() {
+    if ($menu) {
+      $menu.remove();
+      $menu = null;
       $activeHeaderColumn
-        .addClass("slick-header-column-active");
+        .removeClass("slick-header-column-active");
+    }
+  }
 
-      // Stop propagation so that it doesn't register as a header click event.
-      e.preventDefault();
-      e.stopPropagation();
+  function handleHeaderCellRendered(e, args) {
+    var column = args.column;
+    var menu = column.header && column.header.menu;
+
+    if (menu) {
+      var $el = $("<div></div>")
+        .addClass("slick-header-menubutton")
+        .data("column", column)
+        .data("menu", menu);
+
+      if (options.buttonCssClass) {
+        $el.addClass(options.buttonCssClass);
+      }
+
+      if (options.buttonImage) {
+        $el.css("background-image", "url(" + options.buttonImage + ")");
+      }
+
+      if (menu.tooltip) {
+        $el.attr("title", menu.tooltip);
+      }
+
+      $el
+        .bind("click", showMenu)
+        .appendTo(args.node);
+    }
+  }
+
+
+  function handleBeforeHeaderCellDestroy(e, args) {
+    var column = args.column;
+
+    if (column.header && column.header.menu) {
+      $(args.node).find(".slick-header-menubutton").remove();
+    }
+  }
+
+
+  function showMenu(e) {
+    var $menuButton = $(this);
+    var menu = $menuButton.data("menu");
+    var columnDef = $menuButton.data("column");
+
+    // Let the user modify the menu or cancel altogether,
+    // or provide alternative menu implementation.
+    if (_self.onBeforeMenuShow.notify({
+        "grid": _grid,
+        "column": columnDef,
+        "menu": menu
+      }, e, _self) == false) {
+      return;
     }
 
 
-    function handleMenuItemClick(e) {
-      var command = $(this).data("command");
-      var columnDef = $(this).data("column");
-      var item = $(this).data("item");
+    if (!$menu) {
+      $menu = $("<div class='slick-header-menu'></div>")
+        .appendTo(_grid.getContainerNode());
+    }
+    $menu.empty();
+
+
+    // Construct the menu items.
+    for (var i = 0; i < menu.items.length; i++) {
+      var item = menu.items[i];
+
+      var $li = $("<div class='slick-header-menuitem'></div>")
+        .data("command", item.command || '')
+        .data("column", columnDef)
+        .data("item", item)
+        .bind("click", handleMenuItemClick)
+        .appendTo($menu);
 
       if (item.disabled) {
-        return;
+        $li.addClass("slick-header-menuitem-disabled");
       }
 
-      hideMenu();
-
-      if (command != null && command != '') {
-        _self.onCommand.notify({
-            "grid": _grid,
-            "column": columnDef,
-            "command": command,
-            "item": item
-          }, e, _self);
+      if (item.tooltip) {
+        $li.attr("title", item.tooltip);
       }
 
-      // Stop propagation so that it doesn't register as a header click event.
-      e.preventDefault();
-      e.stopPropagation();
+      var $icon = $("<div class='slick-header-menuicon'></div>")
+        .appendTo($li);
+
+      if (item.iconCssClass) {
+        $icon.addClass(item.iconCssClass);
+      }
+
+      if (item.iconImage) {
+        $icon.css("background-image", "url(" + item.iconImage + ")");
+      }
+
+      $("<span class='slick-header-menucontent'></span>")
+        .text(item.title)
+        .appendTo($li);
     }
 
-    $.extend(this, {
-      "init": init,
-      "destroy": destroy,
 
-      "onBeforeMenuShow": new Slick.Event(),
-      "onCommand": new Slick.Event()
-    });
+    // Position the menu.
+    $menu
+      .offset({ top: $(this).offset().top + $(this).height(), left: $(this).offset().left });
+
+
+    // Mark the header as active to keep the highlighting.
+    $activeHeaderColumn = $menuButton.closest(".slick-header-column");
+    $activeHeaderColumn
+      .addClass("slick-header-column-active");
+
+    // Stop propagation so that it doesn't register as a header click event.
+    e.preventDefault();
+    e.stopPropagation();
   }
-})(jQuery);
+
+
+  function handleMenuItemClick(e) {
+    var command = $(this).data("command");
+    var columnDef = $(this).data("column");
+    var item = $(this).data("item");
+
+    if (item.disabled) {
+      return;
+    }
+
+    hideMenu();
+
+    if (command != null && command != '') {
+      _self.onCommand.notify({
+          "grid": _grid,
+          "column": columnDef,
+          "command": command,
+          "item": item
+        }, e, _self);
+    }
+
+    // Stop propagation so that it doesn't register as a header click event.
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  $.extend(this, {
+    "init": init,
+    "destroy": destroy,
+
+    "onBeforeMenuShow": new Slick.Event(),
+    "onCommand": new Slick.Event()
+  });
+}

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -1,144 +1,141 @@
 var Slick = require('../core');
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
+module.exports = RowMoveManager;
 
-  module.exports = RowMoveManager;
-
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "RowMoveManager": RowMoveManager
-    }
-  });
-
-  function RowMoveManager(options) {
-    var _grid;
-    var _canvas;
-    var _dragging;
-    var _self = this;
-    var _handler = new Slick.EventHandler();
-    var _defaults = {
-      cancelEditOnDrag: false
-    };
-
-    function init(grid) {
-      options = $.extend(true, {}, _defaults, options);
-      _grid = grid;
-      _canvas = _grid.getCanvasNode();
-      _handler
-        .subscribe(_grid.onDragInit, handleDragInit)
-        .subscribe(_grid.onDragStart, handleDragStart)
-        .subscribe(_grid.onDrag, handleDrag)
-        .subscribe(_grid.onDragEnd, handleDragEnd);
-    }
-
-    function destroy() {
-      _handler.unsubscribeAll();
-    }
-
-    function handleDragInit(e, dd) {
-      // prevent the grid from cancelling drag'n'drop by default
-      e.stopImmediatePropagation();
-    }
-
-    function handleDragStart(e, dd) {
-      var cell = _grid.getCellFromEvent(e);
-
-      if (options.cancelEditOnDrag && _grid.getEditorLock().isActive()) {
-        _grid.getEditorLock().cancelCurrentEdit();
-      }
-
-      if (_grid.getEditorLock().isActive() || !/move|selectAndMove/.test(_grid.getColumns()[cell.cell].behavior)) {
-        return false;
-      }
-
-      _dragging = true;
-      e.stopImmediatePropagation();
-
-      var selectedRows = _grid.getSelectedRows();
-
-      if (selectedRows.length == 0 || $.inArray(cell.row, selectedRows) == -1) {
-        selectedRows = [cell.row];
-        _grid.setSelectedRows(selectedRows);
-      }
-
-      var rowHeight = _grid.getOptions().rowHeight;
-
-      dd.selectedRows = selectedRows;
-
-      dd.selectionProxy = $("<div class='slick-reorder-proxy'/>")
-          .css("position", "absolute")
-          .css("zIndex", "99999")
-          .css("width", $(_canvas).innerWidth())
-          .css("height", rowHeight * selectedRows.length)
-          .appendTo(_canvas);
-
-      dd.guide = $("<div class='slick-reorder-guide'/>")
-          .css("position", "absolute")
-          .css("zIndex", "99998")
-          .css("width", $(_canvas).innerWidth())
-          .css("top", -1000)
-          .appendTo(_canvas);
-
-      dd.insertBefore = -1;
-    }
-
-    function handleDrag(e, dd) {
-      if (!_dragging) {
-        return;
-      }
-
-      e.stopImmediatePropagation();
-
-      var top = e.pageY - $(_canvas).offset().top;
-      dd.selectionProxy.css("top", top - 5);
-
-      var insertBefore = Math.max(0, Math.min(Math.round(top / _grid.getOptions().rowHeight), _grid.getDataLength()));
-      if (insertBefore !== dd.insertBefore) {
-        var eventData = {
-          "rows": dd.selectedRows,
-          "insertBefore": insertBefore
-        };
-
-        if (_self.onBeforeMoveRows.notify(eventData) === false) {
-          dd.guide.css("top", -1000);
-          dd.canMove = false;
-        } else {
-          dd.guide.css("top", insertBefore * _grid.getOptions().rowHeight);
-          dd.canMove = true;
-        }
-
-        dd.insertBefore = insertBefore;
-      }
-    }
-
-    function handleDragEnd(e, dd) {
-      if (!_dragging) {
-        return;
-      }
-      _dragging = false;
-      e.stopImmediatePropagation();
-
-      dd.guide.remove();
-      dd.selectionProxy.remove();
-
-      if (dd.canMove) {
-        var eventData = {
-          "rows": dd.selectedRows,
-          "insertBefore": dd.insertBefore
-        };
-        // TODO:  _grid.remapCellCssClasses ?
-        _self.onMoveRows.notify(eventData);
-      }
-    }
-
-    $.extend(this, {
-      "onBeforeMoveRows": new Slick.Event(),
-      "onMoveRows": new Slick.Event(),
-
-      "init": init,
-      "destroy": destroy
-    });
+// register namespace
+$.extend(true, window, {
+  "Slick": {
+    "RowMoveManager": RowMoveManager
   }
-})(jQuery);
+});
+
+function RowMoveManager(options) {
+  var _grid;
+  var _canvas;
+  var _dragging;
+  var _self = this;
+  var _handler = new Slick.EventHandler();
+  var _defaults = {
+    cancelEditOnDrag: false
+  };
+
+  function init(grid) {
+    options = $.extend(true, {}, _defaults, options);
+    _grid = grid;
+    _canvas = _grid.getCanvasNode();
+    _handler
+      .subscribe(_grid.onDragInit, handleDragInit)
+      .subscribe(_grid.onDragStart, handleDragStart)
+      .subscribe(_grid.onDrag, handleDrag)
+      .subscribe(_grid.onDragEnd, handleDragEnd);
+  }
+
+  function destroy() {
+    _handler.unsubscribeAll();
+  }
+
+  function handleDragInit(e, dd) {
+    // prevent the grid from cancelling drag'n'drop by default
+    e.stopImmediatePropagation();
+  }
+
+  function handleDragStart(e, dd) {
+    var cell = _grid.getCellFromEvent(e);
+
+    if (options.cancelEditOnDrag && _grid.getEditorLock().isActive()) {
+      _grid.getEditorLock().cancelCurrentEdit();
+    }
+
+    if (_grid.getEditorLock().isActive() || !/move|selectAndMove/.test(_grid.getColumns()[cell.cell].behavior)) {
+      return false;
+    }
+
+    _dragging = true;
+    e.stopImmediatePropagation();
+
+    var selectedRows = _grid.getSelectedRows();
+
+    if (selectedRows.length == 0 || $.inArray(cell.row, selectedRows) == -1) {
+      selectedRows = [cell.row];
+      _grid.setSelectedRows(selectedRows);
+    }
+
+    var rowHeight = _grid.getOptions().rowHeight;
+
+    dd.selectedRows = selectedRows;
+
+    dd.selectionProxy = $("<div class='slick-reorder-proxy'/>")
+        .css("position", "absolute")
+        .css("zIndex", "99999")
+        .css("width", $(_canvas).innerWidth())
+        .css("height", rowHeight * selectedRows.length)
+        .appendTo(_canvas);
+
+    dd.guide = $("<div class='slick-reorder-guide'/>")
+        .css("position", "absolute")
+        .css("zIndex", "99998")
+        .css("width", $(_canvas).innerWidth())
+        .css("top", -1000)
+        .appendTo(_canvas);
+
+    dd.insertBefore = -1;
+  }
+
+  function handleDrag(e, dd) {
+    if (!_dragging) {
+      return;
+    }
+
+    e.stopImmediatePropagation();
+
+    var top = e.pageY - $(_canvas).offset().top;
+    dd.selectionProxy.css("top", top - 5);
+
+    var insertBefore = Math.max(0, Math.min(Math.round(top / _grid.getOptions().rowHeight), _grid.getDataLength()));
+    if (insertBefore !== dd.insertBefore) {
+      var eventData = {
+        "rows": dd.selectedRows,
+        "insertBefore": insertBefore
+      };
+
+      if (_self.onBeforeMoveRows.notify(eventData) === false) {
+        dd.guide.css("top", -1000);
+        dd.canMove = false;
+      } else {
+        dd.guide.css("top", insertBefore * _grid.getOptions().rowHeight);
+        dd.canMove = true;
+      }
+
+      dd.insertBefore = insertBefore;
+    }
+  }
+
+  function handleDragEnd(e, dd) {
+    if (!_dragging) {
+      return;
+    }
+    _dragging = false;
+    e.stopImmediatePropagation();
+
+    dd.guide.remove();
+    dd.selectionProxy.remove();
+
+    if (dd.canMove) {
+      var eventData = {
+        "rows": dd.selectedRows,
+        "insertBefore": dd.insertBefore
+      };
+      // TODO:  _grid.remapCellCssClasses ?
+      _self.onMoveRows.notify(eventData);
+    }
+  }
+
+  $.extend(this, {
+    "onBeforeMoveRows": new Slick.Event(),
+    "onMoveRows": new Slick.Event(),
+
+    "init": init,
+    "destroy": destroy
+  });
+}

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -1,4 +1,5 @@
 var Slick = require('../core');
+var jQuery = require("jquery");
 
 (function ($) {
 

--- a/plugins/slick.rowselectionmodel.js
+++ b/plugins/slick.rowselectionmodel.js
@@ -1,193 +1,190 @@
 var Slick = require('../core');
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
+module.exports = RowSelectionModel;
 
-  module.exports = RowSelectionModel;
-
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "RowSelectionModel": RowSelectionModel
-    }
-  });
-
-  function RowSelectionModel(options) {
-    var _grid;
-    var _ranges = [];
-    var _self = this;
-    var _handler = new Slick.EventHandler();
-    var _inHandler;
-    var _options;
-    var _defaults = {
-      selectActiveRow: true
-    };
-
-    function init(grid) {
-      _options = $.extend(true, {}, _defaults, options);
-      _grid = grid;
-      _handler.subscribe(_grid.onActiveCellChanged,
-          wrapHandler(handleActiveCellChange));
-      _handler.subscribe(_grid.onKeyDown,
-          wrapHandler(handleKeyDown));
-      _handler.subscribe(_grid.onClick,
-          wrapHandler(handleClick));
-    }
-
-    function destroy() {
-      _handler.unsubscribeAll();
-    }
-
-    function wrapHandler(handler) {
-      return function () {
-        if (!_inHandler) {
-          _inHandler = true;
-          handler.apply(this, arguments);
-          _inHandler = false;
-        }
-      };
-    }
-
-    function rangesToRows(ranges) {
-      var rows = [];
-      for (var i = 0; i < ranges.length; i++) {
-        for (var j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
-          rows.push(j);
-        }
-      }
-      return rows;
-    }
-
-    function rowsToRanges(rows) {
-      var ranges = [];
-      var lastCell = _grid.getColumns().length - 1;
-      for (var i = 0; i < rows.length; i++) {
-        ranges.push(new Slick.Range(rows[i], 0, rows[i], lastCell));
-      }
-      return ranges;
-    }
-
-    function getRowsRange(from, to) {
-      var i, rows = [];
-      for (i = from; i <= to; i++) {
-        rows.push(i);
-      }
-      for (i = to; i < from; i++) {
-        rows.push(i);
-      }
-      return rows;
-    }
-
-    function getSelectedRows() {
-      return rangesToRows(_ranges);
-    }
-
-    function setSelectedRows(rows) {
-      setSelectedRanges(rowsToRanges(rows));
-    }
-
-    function setSelectedRanges(ranges) {
-      _ranges = ranges;
-      _self.onSelectedRangesChanged.notify(_ranges);
-    }
-
-    function getSelectedRanges() {
-      return _ranges;
-    }
-
-    function handleActiveCellChange(e, data) {
-      if (_options.selectActiveRow && data.row != null) {
-        setSelectedRanges([new Slick.Range(data.row, 0, data.row, _grid.getColumns().length - 1)]);
-      }
-    }
-
-    function handleKeyDown(e) {
-      var activeRow = _grid.getActiveCell();
-      if (activeRow && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey && (e.which == 38 || e.which == 40)) {
-        var selectedRows = getSelectedRows();
-        selectedRows.sort(function (x, y) {
-          return x - y
-        });
-
-        if (!selectedRows.length) {
-          selectedRows = [activeRow.row];
-        }
-
-        var top = selectedRows[0];
-        var bottom = selectedRows[selectedRows.length - 1];
-        var active;
-
-        if (e.which == 40) {
-          active = activeRow.row < bottom || top == bottom ? ++bottom : ++top;
-        } else {
-          active = activeRow.row < bottom ? --bottom : --top;
-        }
-
-        if (active >= 0 && active < _grid.getDataLength()) {
-          _grid.scrollRowIntoView(active);
-          _ranges = rowsToRanges(getRowsRange(top, bottom));
-          setSelectedRanges(_ranges);
-        }
-
-        e.preventDefault();
-        e.stopPropagation();
-      }
-    }
-
-    function handleClick(e) {
-      var cell = _grid.getCellFromEvent(e);
-      if (!cell || !_grid.canCellBeActive(cell.row, cell.cell)) {
-        return false;
-      }
-
-      if (!_grid.getOptions().multiSelect || (
-          !e.ctrlKey && !e.shiftKey && !e.metaKey)) {
-        return false;
-      }
-
-      var selection = rangesToRows(_ranges);
-      var idx = $.inArray(cell.row, selection);
-
-      if (idx === -1 && (e.ctrlKey || e.metaKey)) {
-        selection.push(cell.row);
-        _grid.setActiveCell(cell.row, cell.cell);
-      } else if (idx !== -1 && (e.ctrlKey || e.metaKey)) {
-        selection = $.grep(selection, function (o, i) {
-          return (o !== cell.row);
-        });
-        _grid.setActiveCell(cell.row, cell.cell);
-      } else if (selection.length && e.shiftKey) {
-        var last = selection.pop();
-        var from = Math.min(cell.row, last);
-        var to = Math.max(cell.row, last);
-        selection = [];
-        for (var i = from; i <= to; i++) {
-          if (i !== last) {
-            selection.push(i);
-          }
-        }
-        selection.push(last);
-        _grid.setActiveCell(cell.row, cell.cell);
-      }
-
-      _ranges = rowsToRanges(selection);
-      setSelectedRanges(_ranges);
-      e.stopImmediatePropagation();
-
-      return true;
-    }
-
-    $.extend(this, {
-      "getSelectedRows": getSelectedRows,
-      "setSelectedRows": setSelectedRows,
-
-      "getSelectedRanges": getSelectedRanges,
-      "setSelectedRanges": setSelectedRanges,
-
-      "init": init,
-      "destroy": destroy,
-
-      "onSelectedRangesChanged": new Slick.Event()
-    });
+// register namespace
+$.extend(true, window, {
+  "Slick": {
+    "RowSelectionModel": RowSelectionModel
   }
-})(jQuery);
+});
+
+function RowSelectionModel(options) {
+  var _grid;
+  var _ranges = [];
+  var _self = this;
+  var _handler = new Slick.EventHandler();
+  var _inHandler;
+  var _options;
+  var _defaults = {
+    selectActiveRow: true
+  };
+
+  function init(grid) {
+    _options = $.extend(true, {}, _defaults, options);
+    _grid = grid;
+    _handler.subscribe(_grid.onActiveCellChanged,
+        wrapHandler(handleActiveCellChange));
+    _handler.subscribe(_grid.onKeyDown,
+        wrapHandler(handleKeyDown));
+    _handler.subscribe(_grid.onClick,
+        wrapHandler(handleClick));
+  }
+
+  function destroy() {
+    _handler.unsubscribeAll();
+  }
+
+  function wrapHandler(handler) {
+    return function () {
+      if (!_inHandler) {
+        _inHandler = true;
+        handler.apply(this, arguments);
+        _inHandler = false;
+      }
+    };
+  }
+
+  function rangesToRows(ranges) {
+    var rows = [];
+    for (var i = 0; i < ranges.length; i++) {
+      for (var j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
+        rows.push(j);
+      }
+    }
+    return rows;
+  }
+
+  function rowsToRanges(rows) {
+    var ranges = [];
+    var lastCell = _grid.getColumns().length - 1;
+    for (var i = 0; i < rows.length; i++) {
+      ranges.push(new Slick.Range(rows[i], 0, rows[i], lastCell));
+    }
+    return ranges;
+  }
+
+  function getRowsRange(from, to) {
+    var i, rows = [];
+    for (i = from; i <= to; i++) {
+      rows.push(i);
+    }
+    for (i = to; i < from; i++) {
+      rows.push(i);
+    }
+    return rows;
+  }
+
+  function getSelectedRows() {
+    return rangesToRows(_ranges);
+  }
+
+  function setSelectedRows(rows) {
+    setSelectedRanges(rowsToRanges(rows));
+  }
+
+  function setSelectedRanges(ranges) {
+    _ranges = ranges;
+    _self.onSelectedRangesChanged.notify(_ranges);
+  }
+
+  function getSelectedRanges() {
+    return _ranges;
+  }
+
+  function handleActiveCellChange(e, data) {
+    if (_options.selectActiveRow && data.row != null) {
+      setSelectedRanges([new Slick.Range(data.row, 0, data.row, _grid.getColumns().length - 1)]);
+    }
+  }
+
+  function handleKeyDown(e) {
+    var activeRow = _grid.getActiveCell();
+    if (activeRow && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey && (e.which == 38 || e.which == 40)) {
+      var selectedRows = getSelectedRows();
+      selectedRows.sort(function (x, y) {
+        return x - y
+      });
+
+      if (!selectedRows.length) {
+        selectedRows = [activeRow.row];
+      }
+
+      var top = selectedRows[0];
+      var bottom = selectedRows[selectedRows.length - 1];
+      var active;
+
+      if (e.which == 40) {
+        active = activeRow.row < bottom || top == bottom ? ++bottom : ++top;
+      } else {
+        active = activeRow.row < bottom ? --bottom : --top;
+      }
+
+      if (active >= 0 && active < _grid.getDataLength()) {
+        _grid.scrollRowIntoView(active);
+        _ranges = rowsToRanges(getRowsRange(top, bottom));
+        setSelectedRanges(_ranges);
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }
+
+  function handleClick(e) {
+    var cell = _grid.getCellFromEvent(e);
+    if (!cell || !_grid.canCellBeActive(cell.row, cell.cell)) {
+      return false;
+    }
+
+    if (!_grid.getOptions().multiSelect || (
+        !e.ctrlKey && !e.shiftKey && !e.metaKey)) {
+      return false;
+    }
+
+    var selection = rangesToRows(_ranges);
+    var idx = $.inArray(cell.row, selection);
+
+    if (idx === -1 && (e.ctrlKey || e.metaKey)) {
+      selection.push(cell.row);
+      _grid.setActiveCell(cell.row, cell.cell);
+    } else if (idx !== -1 && (e.ctrlKey || e.metaKey)) {
+      selection = $.grep(selection, function (o, i) {
+        return (o !== cell.row);
+      });
+      _grid.setActiveCell(cell.row, cell.cell);
+    } else if (selection.length && e.shiftKey) {
+      var last = selection.pop();
+      var from = Math.min(cell.row, last);
+      var to = Math.max(cell.row, last);
+      selection = [];
+      for (var i = from; i <= to; i++) {
+        if (i !== last) {
+          selection.push(i);
+        }
+      }
+      selection.push(last);
+      _grid.setActiveCell(cell.row, cell.cell);
+    }
+
+    _ranges = rowsToRanges(selection);
+    setSelectedRanges(_ranges);
+    e.stopImmediatePropagation();
+
+    return true;
+  }
+
+  $.extend(this, {
+    "getSelectedRows": getSelectedRows,
+    "setSelectedRows": setSelectedRows,
+
+    "getSelectedRanges": getSelectedRanges,
+    "setSelectedRanges": setSelectedRanges,
+
+    "init": init,
+    "destroy": destroy,
+
+    "onSelectedRangesChanged": new Slick.Event()
+  });
+}

--- a/plugins/slick.rowselectionmodel.js
+++ b/plugins/slick.rowselectionmodel.js
@@ -1,4 +1,5 @@
 var Slick = require('../core');
+var jQuery = require("jquery");
 
 (function ($) {
 

--- a/remotemodel.js
+++ b/remotemodel.js
@@ -1,3 +1,5 @@
+var jQuery = require("jquery");
+
 (function ($) {
   /***
    * A sample AJAX data store implementation.
@@ -115,7 +117,7 @@
         var item = resp.results[i].item;
 
         // Old IE versions can't parse ISO dates, so change to universally-supported format.
-        item.create_ts = item.create_ts.replace(/^(\d+)-(\d+)-(\d+)T(\d+:\d+:\d+)Z$/, "$2/$3/$1 $4 UTC"); 
+        item.create_ts = item.create_ts.replace(/^(\d+)-(\d+)-(\d+)T(\d+:\d+:\d+)Z$/, "$2/$3/$1 $4 UTC");
         item.create_ts = new Date(item.create_ts);
 
         data[from + i] = item;

--- a/remotemodel.js
+++ b/remotemodel.js
@@ -1,175 +1,173 @@
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
-  /***
-   * A sample AJAX data store implementation.
-   * Right now, it's hooked up to load Hackernews stories, but can
-   * easily be extended to support any JSONP-compatible backend that accepts paging parameters.
-   */
-  function RemoteModel() {
-    // private
-    var PAGESIZE = 50;
-    var data = {length: 0};
-    var searchstr = "";
-    var sortcol = null;
-    var sortdir = 1;
-    var h_request = null;
-    var req = null; // ajax request
+/***
+ * A sample AJAX data store implementation.
+ * Right now, it's hooked up to load Hackernews stories, but can
+ * easily be extended to support any JSONP-compatible backend that accepts paging parameters.
+ */
+function RemoteModel() {
+  // private
+  var PAGESIZE = 50;
+  var data = {length: 0};
+  var searchstr = "";
+  var sortcol = null;
+  var sortdir = 1;
+  var h_request = null;
+  var req = null; // ajax request
 
-    // events
-    var onDataLoading = new Slick.Event();
-    var onDataLoaded = new Slick.Event();
-
-
-    function init() {
-    }
+  // events
+  var onDataLoading = new Slick.Event();
+  var onDataLoaded = new Slick.Event();
 
 
-    function isDataLoaded(from, to) {
-      for (var i = from; i <= to; i++) {
-        if (data[i] == undefined || data[i] == null) {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-
-    function clear() {
-      for (var key in data) {
-        delete data[key];
-      }
-      data.length = 0;
-    }
-
-
-    function ensureData(from, to) {
-      if (req) {
-        req.abort();
-        for (var i = req.fromPage; i <= req.toPage; i++)
-          data[i * PAGESIZE] = undefined;
-      }
-
-      if (from < 0) {
-        from = 0;
-      }
-
-      if (data.length > 0) {
-        to = Math.min(to, data.length - 1);
-      }
-
-      var fromPage = Math.floor(from / PAGESIZE);
-      var toPage = Math.floor(to / PAGESIZE);
-
-      while (data[fromPage * PAGESIZE] !== undefined && fromPage < toPage)
-        fromPage++;
-
-      while (data[toPage * PAGESIZE] !== undefined && fromPage < toPage)
-        toPage--;
-
-      if (fromPage > toPage || ((fromPage == toPage) && data[fromPage * PAGESIZE] !== undefined)) {
-        // TODO:  look-ahead
-        onDataLoaded.notify({from: from, to: to});
-        return;
-      }
-
-      var url = "http://api.thriftdb.com/api.hnsearch.com/items/_search?filter[fields][type][]=submission&q=" + searchstr + "&start=" + (fromPage * PAGESIZE) + "&limit=" + (((toPage - fromPage) * PAGESIZE) + PAGESIZE);
-
-      if (sortcol != null) {
-          url += ("&sortby=" + sortcol + ((sortdir > 0) ? "+asc" : "+desc"));
-      }
-
-      if (h_request != null) {
-        clearTimeout(h_request);
-      }
-
-      h_request = setTimeout(function () {
-        for (var i = fromPage; i <= toPage; i++)
-          data[i * PAGESIZE] = null; // null indicates a 'requested but not available yet'
-
-        onDataLoading.notify({from: from, to: to});
-
-        req = $.jsonp({
-          url: url,
-          callbackParameter: "callback",
-          cache: true,
-          success: onSuccess,
-          error: function () {
-            onError(fromPage, toPage)
-          }
-        });
-        req.fromPage = fromPage;
-        req.toPage = toPage;
-      }, 50);
-    }
-
-
-    function onError(fromPage, toPage) {
-      alert("error loading pages " + fromPage + " to " + toPage);
-    }
-
-    function onSuccess(resp) {
-      var from = resp.request.start, to = from + resp.results.length;
-      data.length = Math.min(parseInt(resp.hits),1000); // limitation of the API
-
-      for (var i = 0; i < resp.results.length; i++) {
-        var item = resp.results[i].item;
-
-        // Old IE versions can't parse ISO dates, so change to universally-supported format.
-        item.create_ts = item.create_ts.replace(/^(\d+)-(\d+)-(\d+)T(\d+:\d+:\d+)Z$/, "$2/$3/$1 $4 UTC");
-        item.create_ts = new Date(item.create_ts);
-
-        data[from + i] = item;
-        data[from + i].index = from + i;
-      }
-
-      req = null;
-
-      onDataLoaded.notify({from: from, to: to});
-    }
-
-
-    function reloadData(from, to) {
-      for (var i = from; i <= to; i++)
-        delete data[i];
-
-      ensureData(from, to);
-    }
-
-
-    function setSort(column, dir) {
-      sortcol = column;
-      sortdir = dir;
-      clear();
-    }
-
-    function setSearch(str) {
-      searchstr = str;
-      clear();
-    }
-
-
-    init();
-
-    return {
-      // properties
-      "data": data,
-
-      // methods
-      "clear": clear,
-      "isDataLoaded": isDataLoaded,
-      "ensureData": ensureData,
-      "reloadData": reloadData,
-      "setSort": setSort,
-      "setSearch": setSearch,
-
-      // events
-      "onDataLoading": onDataLoading,
-      "onDataLoaded": onDataLoaded
-    };
+  function init() {
   }
 
-  // Slick.Data.RemoteModel
-  $.extend(true, window, { Slick: { Data: { RemoteModel: RemoteModel }}});
-})(jQuery);
+
+  function isDataLoaded(from, to) {
+    for (var i = from; i <= to; i++) {
+      if (data[i] == undefined || data[i] == null) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+
+  function clear() {
+    for (var key in data) {
+      delete data[key];
+    }
+    data.length = 0;
+  }
+
+
+  function ensureData(from, to) {
+    if (req) {
+      req.abort();
+      for (var i = req.fromPage; i <= req.toPage; i++)
+        data[i * PAGESIZE] = undefined;
+    }
+
+    if (from < 0) {
+      from = 0;
+    }
+
+    if (data.length > 0) {
+      to = Math.min(to, data.length - 1);
+    }
+
+    var fromPage = Math.floor(from / PAGESIZE);
+    var toPage = Math.floor(to / PAGESIZE);
+
+    while (data[fromPage * PAGESIZE] !== undefined && fromPage < toPage)
+      fromPage++;
+
+    while (data[toPage * PAGESIZE] !== undefined && fromPage < toPage)
+      toPage--;
+
+    if (fromPage > toPage || ((fromPage == toPage) && data[fromPage * PAGESIZE] !== undefined)) {
+      // TODO:  look-ahead
+      onDataLoaded.notify({from: from, to: to});
+      return;
+    }
+
+    var url = "http://api.thriftdb.com/api.hnsearch.com/items/_search?filter[fields][type][]=submission&q=" + searchstr + "&start=" + (fromPage * PAGESIZE) + "&limit=" + (((toPage - fromPage) * PAGESIZE) + PAGESIZE);
+
+    if (sortcol != null) {
+        url += ("&sortby=" + sortcol + ((sortdir > 0) ? "+asc" : "+desc"));
+    }
+
+    if (h_request != null) {
+      clearTimeout(h_request);
+    }
+
+    h_request = setTimeout(function () {
+      for (var i = fromPage; i <= toPage; i++)
+        data[i * PAGESIZE] = null; // null indicates a 'requested but not available yet'
+
+      onDataLoading.notify({from: from, to: to});
+
+      req = $.jsonp({
+        url: url,
+        callbackParameter: "callback",
+        cache: true,
+        success: onSuccess,
+        error: function () {
+          onError(fromPage, toPage)
+        }
+      });
+      req.fromPage = fromPage;
+      req.toPage = toPage;
+    }, 50);
+  }
+
+
+  function onError(fromPage, toPage) {
+    alert("error loading pages " + fromPage + " to " + toPage);
+  }
+
+  function onSuccess(resp) {
+    var from = resp.request.start, to = from + resp.results.length;
+    data.length = Math.min(parseInt(resp.hits),1000); // limitation of the API
+
+    for (var i = 0; i < resp.results.length; i++) {
+      var item = resp.results[i].item;
+
+      // Old IE versions can't parse ISO dates, so change to universally-supported format.
+      item.create_ts = item.create_ts.replace(/^(\d+)-(\d+)-(\d+)T(\d+:\d+:\d+)Z$/, "$2/$3/$1 $4 UTC");
+      item.create_ts = new Date(item.create_ts);
+
+      data[from + i] = item;
+      data[from + i].index = from + i;
+    }
+
+    req = null;
+
+    onDataLoaded.notify({from: from, to: to});
+  }
+
+
+  function reloadData(from, to) {
+    for (var i = from; i <= to; i++)
+      delete data[i];
+
+    ensureData(from, to);
+  }
+
+
+  function setSort(column, dir) {
+    sortcol = column;
+    sortdir = dir;
+    clear();
+  }
+
+  function setSearch(str) {
+    searchstr = str;
+    clear();
+  }
+
+
+  init();
+
+  return {
+    // properties
+    "data": data,
+
+    // methods
+    "clear": clear,
+    "isDataLoaded": isDataLoaded,
+    "ensureData": ensureData,
+    "reloadData": reloadData,
+    "setSort": setSort,
+    "setSearch": setSearch,
+
+    // events
+    "onDataLoading": onDataLoading,
+    "onDataLoaded": onDataLoaded
+  };
+}
+
+// Slick.Data.RemoteModel
+$.extend(true, window, { Slick: { Data: { RemoteModel: RemoteModel }}});

--- a/tests/dataview/dataview.js
+++ b/tests/dataview/dataview.js
@@ -1,6 +1,4 @@
-var jQuery = require("jquery");
-
-(function($) {
+var $ = require("jquery");
 
 module("basic");
 
@@ -842,4 +840,4 @@ test("delete at the end", function() {
 // TODO: combination
 
 
-})(jQuery);
+

--- a/tests/dataview/dataview.js
+++ b/tests/dataview/dataview.js
@@ -1,3 +1,5 @@
+var jQuery = require("jquery");
+
 (function($) {
 
 module("basic");
@@ -475,7 +477,7 @@ test("updating an item to pass the filter", function() {
         same(args.pageSize, 0, "pageSize arg");
         same(args.pageNum, 0, "pageNum arg");
         same(args.totalRows, 4, "totalRows arg");
-        count++;        
+        count++;
     });
     dv.updateItem(3,{id:3,val:3});
     equal(count, 3, "events fired");

--- a/tests/grid/grid.js
+++ b/tests/grid/grid.js
@@ -1,70 +1,66 @@
-var jQuery = require("jquery");
+var $ = require("jquery");
 
-(function ($) {
+var grid;
+var el, offsetBefore, offsetAfter, dragged;
 
-  var grid;
-  var el, offsetBefore, offsetAfter, dragged;
-
-  var drag = function(handle, dx, dy) {
-    offsetBefore = el.offset();
-    $(handle).simulate("drag", {
-      dx: dx || 0,
-      dy: dy || 0
-    });
-    dragged = { dx: dx, dy: dy };
-    offsetAfter = el.offset();
-  }
-
-  var moved = function (dx, dy, msg) {
-    msg = msg ? msg + "." : "";
-    var actual = { left: offsetAfter.left, top: offsetAfter.top };
-    var expected = { left: offsetBefore.left + dx, top: offsetBefore.top + dy };
-    same(actual, expected, 'dragged[' + dragged.dx + ', ' + dragged.dy + '] ' + msg);
-  }
-
-  var ROWS = 500, COLS = 10;
-  var data = [], row;
-  for (var i = 0; i < ROWS; i++) {
-    row = { id: "id_" + i };
-    for (var j = 0; j < COLS; j++) {
-      row["col_" + j] = i + "." + j;
-    }
-    data.push(row);
-  }
-
-  var cols = [], col;
-  for (var i = 0; i < COLS; i++) {
-    cols.push({
-      id: "col" + i,
-      field: "col_" + i,
-      name: "col_" + i
-    });
-  }
-
-  cols[0].minWidth = 70;
-
-  grid = new Slick.Grid("#container", data, cols);
-  grid.render();
-
-  module("grid - column resizing");
-
-  test("minWidth is respected", function () {
-    var firstCol = $("#container .slick-header-column:first");
-    firstCol.find(".slick-resizable-handle:first").simulate("drag", { dx: 100,  dy: 0 });
-    firstCol.find(".slick-resizable-handle:first").simulate("drag", { dx: -200, dy: 0 });
-    equal(firstCol.outerWidth(), 70, "width set to minWidth");
+var drag = function(handle, dx, dy) {
+  offsetBefore = el.offset();
+  $(handle).simulate("drag", {
+    dx: dx || 0,
+    dy: dy || 0
   });
+  dragged = { dx: dx, dy: dy };
+  offsetAfter = el.offset();
+}
 
-  test("onColumnsResized is fired on column resize", function () {
-    expect(2);
-    grid.onColumnsResized.subscribe(function() { ok(true,"onColumnsResized called") });
-    var oldWidth = cols[0].width;
-    $("#container .slick-resizable-handle:first").simulate("drag", { dx: 100, dy: 0 });
-    equal(cols[0].width, oldWidth+100-1, "columns array is updated");
+var moved = function (dx, dy, msg) {
+  msg = msg ? msg + "." : "";
+  var actual = { left: offsetAfter.left, top: offsetAfter.top };
+  var expected = { left: offsetBefore.left + dx, top: offsetBefore.top + dy };
+  same(actual, expected, 'dragged[' + dragged.dx + ', ' + dragged.dy + '] ' + msg);
+}
+
+var ROWS = 500, COLS = 10;
+var data = [], row;
+for (var i = 0; i < ROWS; i++) {
+  row = { id: "id_" + i };
+  for (var j = 0; j < COLS; j++) {
+    row["col_" + j] = i + "." + j;
+  }
+  data.push(row);
+}
+
+var cols = [], col;
+for (var i = 0; i < COLS; i++) {
+  cols.push({
+    id: "col" + i,
+    field: "col_" + i,
+    name: "col_" + i
   });
+}
 
-  test("getData should return data", function () {
-    equal(grid.getData(), data);
-  });
+cols[0].minWidth = 70;
 
-})(jQuery);
+grid = new Slick.Grid("#container", data, cols);
+grid.render();
+
+module("grid - column resizing");
+
+test("minWidth is respected", function () {
+  var firstCol = $("#container .slick-header-column:first");
+  firstCol.find(".slick-resizable-handle:first").simulate("drag", { dx: 100,  dy: 0 });
+  firstCol.find(".slick-resizable-handle:first").simulate("drag", { dx: -200, dy: 0 });
+  equal(firstCol.outerWidth(), 70, "width set to minWidth");
+});
+
+test("onColumnsResized is fired on column resize", function () {
+  expect(2);
+  grid.onColumnsResized.subscribe(function() { ok(true,"onColumnsResized called") });
+  var oldWidth = cols[0].width;
+  $("#container .slick-resizable-handle:first").simulate("drag", { dx: 100, dy: 0 });
+  equal(cols[0].width, oldWidth+100-1, "columns array is updated");
+});
+
+test("getData should return data", function () {
+  equal(grid.getData(), data);
+});

--- a/tests/grid/grid.js
+++ b/tests/grid/grid.js
@@ -1,8 +1,10 @@
+var jQuery = require("jquery");
+
 (function ($) {
-  
+
   var grid;
   var el, offsetBefore, offsetAfter, dragged;
-  
+
   var drag = function(handle, dx, dy) {
     offsetBefore = el.offset();
     $(handle).simulate("drag", {
@@ -12,14 +14,14 @@
     dragged = { dx: dx, dy: dy };
     offsetAfter = el.offset();
   }
-  
+
   var moved = function (dx, dy, msg) {
     msg = msg ? msg + "." : "";
     var actual = { left: offsetAfter.left, top: offsetAfter.top };
     var expected = { left: offsetBefore.left + dx, top: offsetBefore.top + dy };
     same(actual, expected, 'dragged[' + dragged.dx + ', ' + dragged.dy + '] ' + msg);
   }
-  
+
   var ROWS = 500, COLS = 10;
   var data = [], row;
   for (var i = 0; i < ROWS; i++) {
@@ -29,7 +31,7 @@
     }
     data.push(row);
   }
-  
+
   var cols = [], col;
   for (var i = 0; i < COLS; i++) {
     cols.push({
@@ -38,21 +40,21 @@
       name: "col_" + i
     });
   }
-  
+
   cols[0].minWidth = 70;
 
   grid = new Slick.Grid("#container", data, cols);
   grid.render();
 
   module("grid - column resizing");
-  
+
   test("minWidth is respected", function () {
     var firstCol = $("#container .slick-header-column:first");
     firstCol.find(".slick-resizable-handle:first").simulate("drag", { dx: 100,  dy: 0 });
     firstCol.find(".slick-resizable-handle:first").simulate("drag", { dx: -200, dy: 0 });
     equal(firstCol.outerWidth(), 70, "width set to minWidth");
   });
-  
+
   test("onColumnsResized is fired on column resize", function () {
     expect(2);
     grid.onColumnsResized.subscribe(function() { ok(true,"onColumnsResized called") });
@@ -60,9 +62,9 @@
     $("#container .slick-resizable-handle:first").simulate("drag", { dx: 100, dy: 0 });
     equal(cols[0].width, oldWidth+100-1, "columns array is updated");
   });
-  
+
   test("getData should return data", function () {
     equal(grid.getData(), data);
   });
-  
+
 })(jQuery);

--- a/tests/plugins/autotooltips.js
+++ b/tests/plugins/autotooltips.js
@@ -1,3 +1,5 @@
+var jQuery = require("jquery");
+
 (function($) {
 
   var grid,         // The SlickGrid instance
@@ -16,7 +18,7 @@
       TOOLTIP         = "tooltip",
       TRUNCATED_VALUE = LONG_VALUE.substr(0, 17) + "...",
       $container      = $("#container");
-  
+
   // Create data
   for (var i = 0; i < 10; i++) {
     data.push({
@@ -29,104 +31,104 @@
       "tooltipHeader":  i
     });
   }
-  
+
   function setupGrid(pluginOptions) {
     $('<div id="grid" />').appendTo($container);
     grid = new Slick.Grid("#grid", data, cols);
     grid.registerPlugin(new Slick.AutoTooltips(pluginOptions));
     grid.render();
   }
-  
+
   function teardownGrid() {
     $container.empty();
   }
-  
+
   function getCell(columnIndex) {
     return $("#grid .slick-cell.l" + columnIndex).eq(0);
   }
-  
+
   function getHeaderCell(columnIndex) {
     return $("#grid .slick-header-column").eq(columnIndex);
   }
-  
+
   module("plugins - autotooltips - defaults", {
     setup: function () {
       setupGrid({});
     },
     teardown: teardownGrid
   });
-  
+
   test("title is empty when cell text has enough room", function () {
     var $cell = getCell(0);       // Grab a cell
     $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
-    
+
     strictEqual($cell.attr("title"), "", "title is not present");
   });
-  
+
   test("title is present when cell text is cut off", function () {
     var $cell = getCell(2);       // Grab a cell
     $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
-    
+
     strictEqual($cell.attr("title"), LONG_VALUE, "title equals cell text");
   });
-  
+
   module("plugins - autotooltips - header", {
     setup: function () {
       setupGrid({ enableForHeaderCells: true });
     },
     teardown: teardownGrid
   });
-  
+
   test("title is empty when header column has enough width", function () {
     var $headerCell = getHeaderCell(0); // Grab the requested header cell
     $headerCell.trigger("mouseenter");  // Trigger hover on a header cell
-    
+
     strictEqual($headerCell.attr("title"), "", "title is not present");
   });
-  
+
   test("title is present when header column is cut off", function () {
     var $headerCell = getHeaderCell(4); // Grab the requested header cell
     $headerCell.trigger("mouseenter");  // Trigger hover on a header cell
-    
+
     strictEqual($headerCell.attr("title"), "Long header creates tooltip", "title equals column name");
   });
-  
+
   test("title is not overridden when header column has pre-defined tooltip", function() {
     var $headerCell = getHeaderCell(5); // Grab the requested header cell
     $headerCell.trigger("mouseenter");  // Trigger hover on a header cell
-    
+
     strictEqual($headerCell.attr("title"), "Long header with predefined tooltip", "title is not overridden");
   });
-  
+
   // ******************************** //
   // Tests for maximum tooltip length //
   // ******************************** //
-  
+
   module("plugins - autotooltips - max tooltip", {
     setup: function () {
       setupGrid({ maxToolTipLength: 20 });
     },
     teardown: teardownGrid
   });
-  
+
   test("title is empty when cell text has enough room", function () {
     var $cell = getCell(0);       // Grab a cell
     $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
-    
+
     strictEqual($cell.attr("title"), "", "title is not present");
   });
-  
+
   test("title is present and not truncated when cell text is cut off but not too long", function () {
     var $cell = getCell(1);       // Grab a cell
     $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
-    
+
     strictEqual($cell.attr("title"), MEDIUM_VALUE, "title equals truncated text");
   });
-  
+
   test("title is present and truncated when cell text is cut off and too long", function () {
     var $cell = getCell(2);       // Grab a cell
     $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
-    
+
     strictEqual($cell.attr("title"), TRUNCATED_VALUE, "title equals truncated text");
   });
 

--- a/tests/plugins/autotooltips.js
+++ b/tests/plugins/autotooltips.js
@@ -1,135 +1,132 @@
-var jQuery = require("jquery");
 
-(function($) {
+var grid,         // The SlickGrid instance
+    cols = [      // The column definitions
+      { name: "Short",  field: "short",   width: 100 },
+      { name: "Medium", field: "medium",  width: 100 },
+      { name: "Long",   field: "long",    width: 100 },
+      { name: "Mixed",  field: "mixed",   width: 100 },
+      { name: "Long header creates tooltip",         field: "header",        width: 50 },
+      { name: "Long header with predefined tooltip", field: "tooltipHeader", width: 50, tooltip: "Already have a tooltip!" }
+    ],
+    data            = [], // The grid data
+    LONG_VALUE      = "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
+    MEDIUM_VALUE    = "mediummmmmmm"
+    SHORT_VALUE     = "short",
+    TOOLTIP         = "tooltip",
+    TRUNCATED_VALUE = LONG_VALUE.substr(0, 17) + "...",
+    $container      = $("#container");
 
-  var grid,         // The SlickGrid instance
-      cols = [      // The column definitions
-        { name: "Short",  field: "short",   width: 100 },
-        { name: "Medium", field: "medium",  width: 100 },
-        { name: "Long",   field: "long",    width: 100 },
-        { name: "Mixed",  field: "mixed",   width: 100 },
-        { name: "Long header creates tooltip",         field: "header",        width: 50 },
-        { name: "Long header with predefined tooltip", field: "tooltipHeader", width: 50, tooltip: "Already have a tooltip!" }
-      ],
-      data            = [], // The grid data
-      LONG_VALUE      = "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
-      MEDIUM_VALUE    = "mediummmmmmm"
-      SHORT_VALUE     = "short",
-      TOOLTIP         = "tooltip",
-      TRUNCATED_VALUE = LONG_VALUE.substr(0, 17) + "...",
-      $container      = $("#container");
-
-  // Create data
-  for (var i = 0; i < 10; i++) {
-    data.push({
-      "id":             "row" + i,
-      "short":          SHORT_VALUE,
-      "medium":         MEDIUM_VALUE,
-      "long":           LONG_VALUE,
-      "mixed":          ( i % 2 == 0 ? SHORT_VALUE : LONG_VALUE ),
-      "header":         i,
-      "tooltipHeader":  i
-    });
-  }
-
-  function setupGrid(pluginOptions) {
-    $('<div id="grid" />').appendTo($container);
-    grid = new Slick.Grid("#grid", data, cols);
-    grid.registerPlugin(new Slick.AutoTooltips(pluginOptions));
-    grid.render();
-  }
-
-  function teardownGrid() {
-    $container.empty();
-  }
-
-  function getCell(columnIndex) {
-    return $("#grid .slick-cell.l" + columnIndex).eq(0);
-  }
-
-  function getHeaderCell(columnIndex) {
-    return $("#grid .slick-header-column").eq(columnIndex);
-  }
-
-  module("plugins - autotooltips - defaults", {
-    setup: function () {
-      setupGrid({});
-    },
-    teardown: teardownGrid
+// Create data
+for (var i = 0; i < 10; i++) {
+  data.push({
+    "id":             "row" + i,
+    "short":          SHORT_VALUE,
+    "medium":         MEDIUM_VALUE,
+    "long":           LONG_VALUE,
+    "mixed":          ( i % 2 == 0 ? SHORT_VALUE : LONG_VALUE ),
+    "header":         i,
+    "tooltipHeader":  i
   });
+}
 
-  test("title is empty when cell text has enough room", function () {
-    var $cell = getCell(0);       // Grab a cell
-    $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
+function setupGrid(pluginOptions) {
+  $('<div id="grid" />').appendTo($container);
+  grid = new Slick.Grid("#grid", data, cols);
+  grid.registerPlugin(new Slick.AutoTooltips(pluginOptions));
+  grid.render();
+}
 
-    strictEqual($cell.attr("title"), "", "title is not present");
-  });
+function teardownGrid() {
+  $container.empty();
+}
 
-  test("title is present when cell text is cut off", function () {
-    var $cell = getCell(2);       // Grab a cell
-    $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
+function getCell(columnIndex) {
+  return $("#grid .slick-cell.l" + columnIndex).eq(0);
+}
 
-    strictEqual($cell.attr("title"), LONG_VALUE, "title equals cell text");
-  });
+function getHeaderCell(columnIndex) {
+  return $("#grid .slick-header-column").eq(columnIndex);
+}
 
-  module("plugins - autotooltips - header", {
-    setup: function () {
-      setupGrid({ enableForHeaderCells: true });
-    },
-    teardown: teardownGrid
-  });
+module("plugins - autotooltips - defaults", {
+  setup: function () {
+    setupGrid({});
+  },
+  teardown: teardownGrid
+});
 
-  test("title is empty when header column has enough width", function () {
-    var $headerCell = getHeaderCell(0); // Grab the requested header cell
-    $headerCell.trigger("mouseenter");  // Trigger hover on a header cell
+test("title is empty when cell text has enough room", function () {
+  var $cell = getCell(0);       // Grab a cell
+  $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
 
-    strictEqual($headerCell.attr("title"), "", "title is not present");
-  });
+  strictEqual($cell.attr("title"), "", "title is not present");
+});
 
-  test("title is present when header column is cut off", function () {
-    var $headerCell = getHeaderCell(4); // Grab the requested header cell
-    $headerCell.trigger("mouseenter");  // Trigger hover on a header cell
+test("title is present when cell text is cut off", function () {
+  var $cell = getCell(2);       // Grab a cell
+  $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
 
-    strictEqual($headerCell.attr("title"), "Long header creates tooltip", "title equals column name");
-  });
+  strictEqual($cell.attr("title"), LONG_VALUE, "title equals cell text");
+});
 
-  test("title is not overridden when header column has pre-defined tooltip", function() {
-    var $headerCell = getHeaderCell(5); // Grab the requested header cell
-    $headerCell.trigger("mouseenter");  // Trigger hover on a header cell
+module("plugins - autotooltips - header", {
+  setup: function () {
+    setupGrid({ enableForHeaderCells: true });
+  },
+  teardown: teardownGrid
+});
 
-    strictEqual($headerCell.attr("title"), "Long header with predefined tooltip", "title is not overridden");
-  });
+test("title is empty when header column has enough width", function () {
+  var $headerCell = getHeaderCell(0); // Grab the requested header cell
+  $headerCell.trigger("mouseenter");  // Trigger hover on a header cell
 
-  // ******************************** //
-  // Tests for maximum tooltip length //
-  // ******************************** //
+  strictEqual($headerCell.attr("title"), "", "title is not present");
+});
 
-  module("plugins - autotooltips - max tooltip", {
-    setup: function () {
-      setupGrid({ maxToolTipLength: 20 });
-    },
-    teardown: teardownGrid
-  });
+test("title is present when header column is cut off", function () {
+  var $headerCell = getHeaderCell(4); // Grab the requested header cell
+  $headerCell.trigger("mouseenter");  // Trigger hover on a header cell
 
-  test("title is empty when cell text has enough room", function () {
-    var $cell = getCell(0);       // Grab a cell
-    $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
+  strictEqual($headerCell.attr("title"), "Long header creates tooltip", "title equals column name");
+});
 
-    strictEqual($cell.attr("title"), "", "title is not present");
-  });
+test("title is not overridden when header column has pre-defined tooltip", function() {
+  var $headerCell = getHeaderCell(5); // Grab the requested header cell
+  $headerCell.trigger("mouseenter");  // Trigger hover on a header cell
 
-  test("title is present and not truncated when cell text is cut off but not too long", function () {
-    var $cell = getCell(1);       // Grab a cell
-    $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
+  strictEqual($headerCell.attr("title"), "Long header with predefined tooltip", "title is not overridden");
+});
 
-    strictEqual($cell.attr("title"), MEDIUM_VALUE, "title equals truncated text");
-  });
+// ******************************** //
+// Tests for maximum tooltip length //
+// ******************************** //
 
-  test("title is present and truncated when cell text is cut off and too long", function () {
-    var $cell = getCell(2);       // Grab a cell
-    $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
+module("plugins - autotooltips - max tooltip", {
+  setup: function () {
+    setupGrid({ maxToolTipLength: 20 });
+  },
+  teardown: teardownGrid
+});
 
-    strictEqual($cell.attr("title"), TRUNCATED_VALUE, "title equals truncated text");
-  });
+test("title is empty when cell text has enough room", function () {
+  var $cell = getCell(0);       // Grab a cell
+  $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
 
-})(jQuery);
+  strictEqual($cell.attr("title"), "", "title is not present");
+});
+
+test("title is present and not truncated when cell text is cut off but not too long", function () {
+  var $cell = getCell(1);       // Grab a cell
+  $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
+
+  strictEqual($cell.attr("title"), MEDIUM_VALUE, "title equals truncated text");
+});
+
+test("title is present and truncated when cell text is cut off and too long", function () {
+  var $cell = getCell(2);       // Grab a cell
+  $cell.trigger("mouseenter");  // Trigger hover on a cell in grid
+
+  strictEqual($cell.attr("title"), TRUNCATED_VALUE, "title equals truncated text");
+});
+
+


### PR DESCRIPTION
This adds `jquery` as an explicit dependency and uses `require` to load it wherever it is needed. This avoids any dependency on a global `jQuery` object and makes bundles more resilient to module load order.

After pandell/web-pli#181 was merged, it was revealed that `jquery-migrate` was polluting the global namespace with a `jQuery` instance that many slickgrid plugins were depending on. This makes those dependencies explicit.

(Any other visible changes are purely whitespace).