### PR TITLE
Pin jQuery to 2.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "pandell/SlickGrid",
   "author": "Michael Leibman <michael.leibman@gmail.com>",
   "dependencies": {
-    "jquery": "*",
+    "jquery": "^2.2",
     "node.extend": "^1.1"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "pandell/SlickGrid",
   "author": "Michael Leibman <michael.leibman@gmail.com>",
   "dependencies": {
-    "jquery": "^2.2",
+    "jquery": "~2.1",
     "node.extend": "^1.1"
   },
   "directories": {


### PR DESCRIPTION
The newly released jQuery 3.0.0 is incompatible with SlickGrid and we should not automatically upgrade to it. This pull request pins jQuery to 2.1.x.
